### PR TITLE
Fixed naming bug in ops.md

### DIFF
--- a/agent/ops.md
+++ b/agent/ops.md
@@ -33,10 +33,10 @@
 - transfer.clear_low_bits: (!transfer.integer, !transfer.integer) -> !transfer.integer
 - transfer.set_signed_bits: (!transfer.integer, !transfer.integer) -> !transfer.integer
 - transfer.clear_signed_bits: (!transfer.integer, !transfer.integer) -> !transfer.integer
-- transfer.count_l_one: (!transfer.integer) -> !transfer.integer
-- transfer.count_l_zero: (!transfer.integer) -> !transfer.integer
-- transfer.count_r_one: (!transfer.integer) -> !transfer.integer
-- transfer.count_r_zero: (!transfer.integer) -> !transfer.integer
+- transfer.countl_one: (!transfer.integer) -> !transfer.integer
+- transfer.countl_zero: (!transfer.integer) -> !transfer.integer
+- transfer.countr_one: (!transfer.integer) -> !transfer.integer
+- transfer.countr_zero: (!transfer.integer) -> !transfer.integer
 
 ## Utility Operations
 


### PR DESCRIPTION
Fixed bug where transfer.countl_one, transfer.countl_zero, transfer.countr_one, transfer.countr_zero were named transfer.count_l_one, transfer.count_l_zero, etc. in ops.md. This doesn't match what's in [xdsl-smt/dialects/transfer.py](https://github.com/opencompl/xdsl-smt/blob/main/xdsl_smt/dialects/transfer.py), and gave me errors.