### PR TITLE
support skip exact or norm evaluation in eval-final

### DIFF
--- a/synth_xfer/cli/eval_final.py
+++ b/synth_xfer/cli/eval_final.py
@@ -329,14 +329,14 @@ def main() -> None:
         if exact_bw is not None:
             top_8 = next(x for x in top_r.per_bit_res if x.bitwidth == exact_bw)
             synth_8 = next(x for x in synth_r.per_bit_res if x.bitwidth == exact_bw)
-            row["Top Exact %"] = top_8.get_exact_prop() * 100.0
-            row["Synth Exact %"] = synth_8.get_exact_prop() * 100.0
+            row["Top Exact %"] = str(top_8.get_exact_prop() * 100.0)
+            row["Synth Exact %"] = str(synth_8.get_exact_prop() * 100.0)
 
         if norm_bw is not None:
             top_64 = next(x for x in top_r.per_bit_res if x.bitwidth == norm_bw)
             synth_64 = next(x for x in synth_r.per_bit_res if x.bitwidth == norm_bw)
-            row["Top Norm"] = top_64.dist
-            row["Synth Norm"] = synth_64.dist
+            row["Top Norm"] = str(top_64.dist)
+            row["Synth Norm"] = str(synth_64.dist)
 
         rows.append(row)
 


### PR DESCRIPTION
Use `--norm-bw none` to skip norm evaluation in `eval-final`