### PR TITLE
Informative feedback from `eval-final` 

### DIFF
--- a/cpp/bindings/bindings.cpp
+++ b/cpp/bindings/bindings.cpp
@@ -1,5 +1,22 @@
 #include "bindings_common.hpp"
 
+namespace {
+
+template <typename NestedExamples>
+py::list to_py_examples(const NestedExamples &all_examples) {
+  py::list outer;
+  for (const auto &per_xfer : all_examples) {
+    py::list inner;
+    for (const auto &[args, synth, best, distance] : per_xfer) {
+      inner.append(py::make_tuple(py::cast(args), synth, best, distance));
+    }
+    outer.append(std::move(inner));
+  }
+  return outer;
+}
+
+} // namespace
+
 void register_rng(py::module_ &m) {
   using SamplerPtr = std::shared_ptr<rngdist::Sampler>;
 
@@ -50,6 +67,14 @@ void register_results_class(py::module_ &m) {
     std::string s = oss.str();
     s.pop_back();
     return s;
+  });
+
+  cls.def("get_unsound_examples", [](const Results &self) {
+    return to_py_examples(self.getUnsoundExampleTuples());
+  });
+
+  cls.def("get_imprecise_examples", [](const Results &self) {
+    return to_py_examples(self.getImpreciseExampleTuples());
   });
 }
 

--- a/cpp/bindings/bindings_common.hpp
+++ b/cpp/bindings/bindings_common.hpp
@@ -56,7 +56,7 @@ using EnumHighThunk = py::object (*)(std::uintptr_t,
                                      unsigned int, unsigned int, unsigned int,
                                      std::shared_ptr<rngdist::Sampler>);
 using EvalThunk = Results (*)(py::handle, const std::vector<std::uintptr_t> &,
-                              const std::vector<std::uintptr_t> &);
+                              const std::vector<std::uintptr_t> &, unsigned int, unsigned int);
 using RunThunk = py::object (*)(py::handle, std::uintptr_t);
 using LenThunk = std::size_t (*)(py::handle);
 using GetItemThunk = py::object (*)(py::handle, std::size_t);
@@ -222,10 +222,11 @@ void register_eval_domain(py::module_ &m) {
   bind_eval_func(
       m, fn_name,
       +[](py::handle to_eval, const std::vector<std::uintptr_t> &xfers,
-          const std::vector<std::uintptr_t> &bases) -> Results {
+          const std::vector<std::uintptr_t> &bases, unsigned int unsound_ex,
+          unsigned int imprecise_ex) -> Results {
         const EvalVec &v = py::cast<const EvalVec &>(to_eval);
         py::gil_scoped_release release;
-        return EvalT{xfers, bases}.eval(v);
+        return EvalT{xfers, bases, unsound_ex, imprecise_ex}.eval(v);
       });
 }
 

--- a/cpp/bindings/bindings_helpers.cpp
+++ b/cpp/bindings/bindings_helpers.cpp
@@ -92,7 +92,7 @@ void bind_enum_funcs(py::module_ &m, const std::string &fn_name,
 void bind_eval_func(py::module_ &m, const std::string &fn_name,
                     EvalThunk eval) {
   m.def(fn_name.c_str(), eval, py::arg("to_eval"), py::arg("xfers"),
-        py::arg("bases"));
+        py::arg("bases"), py::arg("unsound_ex"), py::arg("imprecise_ex"));
 }
 
 void bind_run_func(py::module_ &m, const std::string &fn_name, RunThunk run) {

--- a/cpp/bindings/bindings_helpers.cpp
+++ b/cpp/bindings/bindings_helpers.cpp
@@ -92,7 +92,7 @@ void bind_enum_funcs(py::module_ &m, const std::string &fn_name,
 void bind_eval_func(py::module_ &m, const std::string &fn_name,
                     EvalThunk eval) {
   m.def(fn_name.c_str(), eval, py::arg("to_eval"), py::arg("xfers"),
-        py::arg("bases"), py::arg("unsound_ex"), py::arg("imprecise_ex"));
+        py::arg("bases"), py::arg("unsound_ex") = 0, py::arg("imprecise_ex") = 0);
 }
 
 void bind_run_func(py::module_ &m, const std::string &fn_name, RunThunk run) {

--- a/cpp/core/eval.hpp
+++ b/cpp/core/eval.hpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <sstream>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -73,11 +75,39 @@ public:
 private:
   std::vector<XferFn> xfrFns;
   std::vector<XferFn> refFns;
+  unsigned int maxUnsoundExamples;
+  unsigned int maxImpreciseExamples;
+
+  template <typename T> static std::string toText(const T &value) {
+    std::ostringstream oss;
+    oss << value;
+    std::string result = oss.str();
+    // Remove trailing newline if present
+    if (!result.empty() && result.back() == '\n') {
+      result.pop_back();
+    }
+    return result;
+  }
+
+  static std::vector<std::string> argsToText(const ArgsTuple &args) {
+    std::vector<std::string> out;
+    out.reserve(N);
+
+    std::apply(
+        [&](const auto &...parts) {
+          (out.push_back(toText(parts)), ...);
+        },
+        args);
+
+    return out;
+  }
 
 public:
   constexpr Eval(const std::vector<std::uintptr_t> &xfrAddrs,
-                 const std::vector<std::uintptr_t> &refAddrs)
-      : xfrFns(xfrAddrs.size(), nullptr), refFns(refAddrs.size(), nullptr) {
+                 const std::vector<std::uintptr_t> &refAddrs,
+                 unsigned int maxUnsound = 0, unsigned int maxImprecise = 0)
+      : xfrFns(xfrAddrs.size(), nullptr), refFns(refAddrs.size(), nullptr),
+        maxUnsoundExamples(maxUnsound), maxImpreciseExamples(maxImprecise) {
     for (std::size_t i = 0; i < xfrFns.size(); ++i)
       xfrFns[i] = reinterpret_cast<XferFn>(xfrAddrs[i]);
     for (std::size_t i = 0; i < refFns.size(); ++i)
@@ -86,14 +116,14 @@ public:
 
   Results eval(const EvalVec &toEval) const {
     Results r{static_cast<unsigned int>(xfrFns.size()), ResBw,
-              ResultD::num_levels};
+              ResultD::num_levels, maxUnsoundExamples, maxImpreciseExamples};
 
     for (const Row &row : toEval) {
       const ArgsTuple &args = std::get<0>(row);
       const ResultD &best = std::get<1>(row);
       evalSingle(args, best, r);
     }
-
+    r.cleanExamples();
     return r;
   }
 
@@ -133,7 +163,10 @@ private:
       unsigned long dis = synth_after_meet.distance(best);
       unsigned long soundDis = sound ? dis : baseDis;
 
-      r.incResult(Result(sound, dis, exact, solved, soundDis), i);
+      CaseExample example(argsToText(args), toText(synth_after_meet),
+                          toText(best), static_cast<double>(dis));
+
+      r.incResult(sound, dis, exact, solved, soundDis, example, i);
     }
 
     r.incCases(solved, baseDis);

--- a/cpp/core/eval.hpp
+++ b/cpp/core/eval.hpp
@@ -78,30 +78,6 @@ private:
   unsigned int maxUnsoundExamples;
   unsigned int maxImpreciseExamples;
 
-  template <typename T> static std::string toText(const T &value) {
-    std::ostringstream oss;
-    oss << value;
-    std::string result = oss.str();
-    // Remove trailing newline if present
-    if (!result.empty() && result.back() == '\n') {
-      result.pop_back();
-    }
-    return result;
-  }
-
-  static std::vector<std::string> argsToText(const ArgsTuple &args) {
-    std::vector<std::string> out;
-    out.reserve(N);
-
-    std::apply(
-        [&](const auto &...parts) {
-          (out.push_back(toText(parts)), ...);
-        },
-        args);
-
-    return out;
-  }
-
 public:
   constexpr Eval(const std::vector<std::uintptr_t> &xfrAddrs,
                  const std::vector<std::uintptr_t> &refAddrs,
@@ -162,11 +138,9 @@ private:
       bool exact = (synth_after_meet == best);
       unsigned long dis = synth_after_meet.distance(best);
       unsigned long soundDis = sound ? dis : baseDis;
-
-      CaseExample example(argsToText(args), toText(synth_after_meet),
-                          toText(best), static_cast<double>(dis));
-
-      r.incResult(sound, dis, exact, solved, soundDis, example, i);
+      // Xuanyu: Creating a CaseExample is expensive, so we passed things to incResult and create it only when necessary.
+      r.incResult(sound, dis, exact, solved, soundDis,
+                  args, synth_after_meet, best, dis, i);
     }
 
     r.incCases(solved, baseDis);

--- a/cpp/core/results.hpp
+++ b/cpp/core/results.hpp
@@ -1,29 +1,54 @@
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <string>
 #include <string_view>
+#include <tuple>
+#include <utility>
 #include <vector>
 
+using CaseExample =
+    std::tuple<std::vector<std::string>, std::string, std::string,
+         double>;
+
 class Result {
+  // The result of evaluating a single transformer on one bitwidth.
 public:
   Result() = default;
 
-  Result(bool s, unsigned long p, bool e, bool solved, unsigned long sd)
-      : sound(s), distance(p), exact(e), soundDistance(sd) {
-    unsolvedExact = !solved ? e : 0;
-  }
+  // Result(bool s, unsigned long p, bool e, bool solved, unsigned long sd,
+  //        const CaseExample &ex = {})
+  //     : sound(s), distance(p), exact(e), soundDistance(sd) {
+  //   unsolvedExact = !solved ? e : 0;
+  //   if (!s)
+  //     unsoundExamples.push_back(ex);
+  //   else if (!e)
+  //     impreciseExamples.push_back(ex);
+  // }
 
-  Result &operator+=(const Result &rhs) {
-    sound += rhs.sound;
-    distance += rhs.distance;
-    exact += rhs.exact;
-    unsolvedExact += rhs.unsolvedExact;
-    soundDistance += rhs.soundDistance;
+  // Result &operator+=(const Result &rhs) {
+  //   sound += rhs.sound;
+  //   distance += rhs.distance;
+  //   exact += rhs.exact;
+  //   unsolvedExact += rhs.unsolvedExact;
+  //   soundDistance += rhs.soundDistance;
 
-    return *this;
-  }
+  //   // Make sure those thershold are 0 when doing synthesis
+  //   if (MAX_UNSOUND_EXAMPLES > 0) {
+  //     unsoundExamples.insert(unsoundExamples.end(), rhs.unsoundExamples.begin(),
+  //                  rhs.unsoundExamples.end());
+  //   }
+  //   if (MAX_IMPRECISE_EXAMPLES > 0) {
+  //     impreciseExamples.insert(impreciseExamples.end(),
+  //                  rhs.impreciseExamples.begin(),
+  //                  rhs.impreciseExamples.end());
+  //   }
+  //   return *this;
+  // }
 
   friend class Results;
 
@@ -33,19 +58,25 @@ private:
   unsigned long exact;
   unsigned long unsolvedExact;
   unsigned long soundDistance;
+  std::vector<CaseExample> unsoundExamples;
+  std::vector<CaseExample> impreciseExamples;
 };
 
 class Results {
+  // The result of evaluating a set of transformers on one bitwidth.
 private:
+  using CaseExamples = std::vector<CaseExample>;
   const unsigned int bw = {};
   std::vector<Result> r;
   unsigned int cases = {};
   unsigned int unsolvedCases = {};
   unsigned int baseDistance = {};
   std::uint64_t (*maxDist)() = {};
+  unsigned int maxUnsoundExamples = 0;
+  unsigned int maxImpreciseExamples = 0;
 
   void printMember(std::ostream &os, std::string_view name,
-                   const std::function<unsigned int(const Result &x)> &getter,
+                   const std::function<unsigned long(const Result &x)> &getter,
                    bool md) const {
     os << std::left << std::setw(20) << name;
     os << "[";
@@ -62,9 +93,29 @@ private:
     }
   }
 
+  template <typename Getter>
+  std::vector<CaseExamples> collectExampleTuples(Getter getter) const {
+    std::vector<CaseExamples> out;
+    out.reserve(r.size());
+    for (const auto &ri : r) {
+      const auto &examples = getter(ri);
+      CaseExamples converted;
+      converted.reserve(examples.size());
+      for (const auto &ex : examples) {
+        converted.emplace_back(std::get<0>(ex), std::get<1>(ex),
+                               std::get<2>(ex),
+                               std::get<3>(ex) / static_cast<double>(maxDist()));
+      }
+      out.push_back(std::move(converted));
+    }
+    return out;
+  }
+
 public:
-  Results(unsigned int numFns, unsigned int bw_, std::uint64_t (*_maxDist)())
-      : bw(bw_), r(std::vector<Result>(numFns)), maxDist(_maxDist) {}
+  Results(unsigned int numFns, unsigned int bw_, std::uint64_t (*_maxDist)(),
+          unsigned int maxUnsound = 0, unsigned int maxImprecise = 0)
+      : bw(bw_), r(std::vector<Result>(numFns)), maxDist(_maxDist),
+        maxUnsoundExamples(maxUnsound), maxImpreciseExamples(maxImprecise) {}
 
   friend std::ostream &operator<<(std::ostream &os, const Results &x) {
     os << std::left << std::setw(20) << "bw:" << x.bw << "\n";
@@ -91,11 +142,57 @@ public:
     return os << "\n";
   }
 
-  void incResult(const Result &newR, unsigned int i) { r[i] += newR; }
+  void incResult(bool s, unsigned long p, bool e, bool solved, unsigned long sd, CaseExample ex, unsigned int i) {
+    r[i].sound += s;
+    r[i].distance += p;
+    r[i].exact += e;
+    r[i].soundDistance += sd;
+    r[i].unsolvedExact += !solved ? e : 0;
+    // Xuanyu: maybe add
+    if (maxUnsoundExamples > r[i].unsoundExamples.size() && !s)
+      r[i].unsoundExamples.push_back(ex);
+    // Xuanyu: maybe when the impreciseExamples it too large, do a sort and only keep the top-k
+    else if (maxImpreciseExamples > 0 && s && !e)
+      r[i].impreciseExamples.push_back(ex);
+  }
 
   void incCases(bool solved, unsigned long dis) {
     cases += 1;
     unsolvedCases += !solved ? 1 : 0;
     baseDistance += dis;
+  }
+
+  void cleanExamples(){
+    for (auto &result : r) {
+      // Keep only the first maxUnsoundExamples
+      if (maxUnsoundExamples > 0 && result.unsoundExamples.size() > maxUnsoundExamples) {
+        result.unsoundExamples.resize(maxUnsoundExamples);
+      }
+      // Keep only the top maxImpreciseExamples with maximum distance
+      if (maxImpreciseExamples > 0 && result.impreciseExamples.size() > maxImpreciseExamples) {
+        // Sort by distance (descending) - the fourth element of the tuple
+        std::sort(result.impreciseExamples.begin(), result.impreciseExamples.end(),
+                  [](const CaseExample &a, const CaseExample &b) {
+                    return std::get<3>(a) > std::get<3>(b);
+                  });
+        result.impreciseExamples.resize(maxImpreciseExamples);
+      }
+    }
+  }
+
+
+  std::vector<CaseExamples> getUnsoundExampleTuples() const {
+
+    return collectExampleTuples(
+        [](const Result &ri) -> const CaseExamples & {
+          return ri.unsoundExamples;
+        });
+  }
+
+  std::vector<CaseExamples> getImpreciseExampleTuples() const {
+
+    return collectExampleTuples([](const Result &ri) -> const CaseExamples & {
+      return ri.impreciseExamples;
+    });
   }
 };

--- a/cpp/core/results.hpp
+++ b/cpp/core/results.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -13,7 +14,35 @@
 
 using CaseExample =
     std::tuple<std::vector<std::string>, std::string, std::string,
-         double>;
+         unsigned long>;
+
+namespace detail {
+
+template <typename T>
+std::string toText(const T &v) {
+  std::ostringstream oss;
+  oss << v;
+  std::string s = oss.str();
+  if (!s.empty() && s.back() == '\n')
+    s.pop_back();
+  return s;
+}
+
+template <typename ArgsTuple>
+std::vector<std::string> argsToText(const ArgsTuple &args) {
+  std::vector<std::string> out;
+  std::apply([&](const auto &...parts) { (out.push_back(toText(parts)), ...); },
+             args);
+  return out;
+}
+
+template <typename ArgsTuple, typename ResultD>
+CaseExample makeCaseExample(const ArgsTuple &args, const ResultD &synth,
+                            const ResultD &best, unsigned long dis) {
+  return CaseExample(argsToText(args), toText(synth), toText(best), dis);
+}
+
+} // namespace detail
 
 class Result {
   // The result of evaluating a single transformer on one bitwidth.
@@ -104,7 +133,7 @@ private:
       for (const auto &ex : examples) {
         converted.emplace_back(std::get<0>(ex), std::get<1>(ex),
                                std::get<2>(ex),
-                               std::get<3>(ex) / static_cast<double>(maxDist()));
+                               static_cast<double>(std::get<3>(ex)) / static_cast<double>(maxDist()));
       }
       out.push_back(std::move(converted));
     }
@@ -142,18 +171,20 @@ public:
     return os << "\n";
   }
 
-  void incResult(bool s, unsigned long p, bool e, bool solved, unsigned long sd, CaseExample ex, unsigned int i) {
+  template <typename ArgsTuple, typename ResultD>
+  void incResult(bool s, unsigned long p, bool e, bool solved, unsigned long sd,
+                 const ArgsTuple &args, const ResultD &synth,
+                 const ResultD &best, unsigned long dis, unsigned int i) {
     r[i].sound += s;
     r[i].distance += p;
     r[i].exact += e;
     r[i].soundDistance += sd;
     r[i].unsolvedExact += !solved ? e : 0;
-    // Xuanyu: maybe add
     if (maxUnsoundExamples > r[i].unsoundExamples.size() && !s)
-      r[i].unsoundExamples.push_back(ex);
+      r[i].unsoundExamples.push_back(detail::makeCaseExample(args, synth, best, dis));
     // Xuanyu: maybe when the impreciseExamples it too large, do a sort and only keep the top-k
-    else if (maxImpreciseExamples > 0 && s && !e)
-      r[i].impreciseExamples.push_back(ex);
+    else if (5 * maxImpreciseExamples > r[i].impreciseExamples.size() && s && !e)
+      r[i].impreciseExamples.push_back(detail::makeCaseExample(args, synth, best, dis));
   }
 
   void incCases(bool solved, unsigned long dis) {

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -177,7 +177,9 @@ def eval_transfer_func(
     unsound_ex: int = 0,
     imprecise_ex: int = 0,
 ) -> list[EvalResult]:
-    def get_eval_f(x: "ToEval") -> Callable[["ToEval", list[int], list[int], int, int], "Results"]:
+    def get_eval_f(
+        x: "ToEval",
+    ) -> Callable[["ToEval", list[int], list[int], int, int], "Results"]:
         suffix = x.__class__.__name__.lower()[6:]
         func_name = f"eval_{suffix}"
 

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -58,6 +58,17 @@ def get_per_bit(a: "Results") -> list[PerBitRes]:
     num_unsolved_exact_cases = get(x[7], "num unsolved exact", get_ints)
     sound_distance = get(x[8], "sound distance", get_floats)
 
+    # Fetch unsound/imprecise examples from C++ bindings
+    unsound_examples = a.get_unsound_examples()
+    imprecise_examples = a.get_imprecise_examples()
+
+    # for (uex, iex) in zip(unsound_examples, imprecise_examples):
+    #     print("unsound results of ith:")
+    #     for ex in uex:
+    #         print(ex)
+    #     print("imprecise results of ith:")
+    #     for ex in iex:
+    #         print(ex)
     assert len(sound) > 0, "No output from EvalEngine"
     assert (
         len(sound)
@@ -65,6 +76,8 @@ def get_per_bit(a: "Results") -> list[PerBitRes]:
         == len(exact)
         == len(num_unsolved_exact_cases)
         == len(sound_distance)
+        == len(unsound_examples)
+        == len(imprecise_examples)
     ), "EvalEngine output mismatch"
 
     return [
@@ -78,6 +91,8 @@ def get_per_bit(a: "Results") -> list[PerBitRes]:
             base_dist=base_distance,
             sound_dist=sound_distance[i],
             bitwidth=bw,
+            unsound_examples=unsound_examples[i],
+            imprecise_examples=imprecise_examples[i],
         )
         for i in range(len(sound))
     ]
@@ -159,6 +174,8 @@ def get_eval_res(per_bits: list[list[PerBitRes]]) -> list[EvalResult]:
 
 def eval_transfer_func(
     x: dict[int, tuple["ToEval", list[FnPtr], list[FnPtr]]],
+    unsound_ex: int = 0,
+    imprecise_ex: int = 0,
 ) -> list[EvalResult]:
     def get_eval_f(x: "ToEval") -> Callable[["ToEval", list[int], list[int]], "Results"]:
         suffix = x.__class__.__name__.lower()[6:]
@@ -170,7 +187,10 @@ def eval_transfer_func(
     for to_eval, xs, bs in x.values():
         xs_addrs = [x.addr for x in xs]
         bs_addrs = [b.addr for b in bs]
-        per_bits.append(get_per_bit(get_eval_f(to_eval)(to_eval, xs_addrs, bs_addrs)))
+        result = get_eval_f(to_eval)(
+            to_eval, xs_addrs, bs_addrs, unsound_ex, imprecise_ex
+        )
+        per_bits.append(get_per_bit(result))
 
     return get_eval_res(per_bits)
 

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -6,7 +6,7 @@ from xdsl_smt.dialects.transfer import TransIntegerType
 
 from synth_xfer import _eval_engine
 from synth_xfer._util.domain import AbstractDomain
-from synth_xfer._util.eval_result import EvalResult, PerBitRes
+from synth_xfer._util.eval_result import CaseExample, EvalResult, PerBitRes
 from synth_xfer._util.jit import FnPtr, Jit
 from synth_xfer._util.lower import LowerToLLVM
 from synth_xfer._util.parse_mlir import HelperFuncs
@@ -91,8 +91,8 @@ def get_per_bit(a: "Results") -> list[PerBitRes]:
             base_dist=base_distance,
             sound_dist=sound_distance[i],
             bitwidth=bw,
-            unsound_examples=unsound_examples[i],
-            imprecise_examples=imprecise_examples[i],
+            unsound_examples=[CaseExample(*ex) for ex in unsound_examples[i]],
+            imprecise_examples=[CaseExample(*ex) for ex in imprecise_examples[i]],
         )
         for i in range(len(sound))
     ]

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -177,7 +177,7 @@ def eval_transfer_func(
     unsound_ex: int = 0,
     imprecise_ex: int = 0,
 ) -> list[EvalResult]:
-    def get_eval_f(x: "ToEval") -> Callable[["ToEval", list[int], list[int]], "Results"]:
+    def get_eval_f(x: "ToEval") -> Callable[["ToEval", list[int], list[int], int, int], "Results"]:
         suffix = x.__class__.__name__.lower()[6:]
         func_name = f"eval_{suffix}"
 

--- a/synth_xfer/_util/eval_result.py
+++ b/synth_xfer/_util/eval_result.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 
+# Type alias for case examples: (inputs, output, optimal_output, distance)
+CaseExample = tuple[tuple[str, ...], str, str, float]
+
 
 @dataclass
 class PerBitRes:
@@ -33,6 +36,10 @@ class PerBitRes:
     r"sound_dis(f,g) := \sum{a, f(a) is sound} d(f(a) /\ g(a), best(a)) + \sum{a, f(a) is unsound} d(g(a), best(a))"
     "sound_dis is equal to dist if f is sound."
 
+    # Example cases for unsound and imprecise transformers
+    unsound_examples: list[CaseExample]
+    imprecise_examples: list[CaseExample]
+
     def __str__(self):
         s = ""
         s += f"bw: {self.bitwidth:<3}"
@@ -51,6 +58,13 @@ class PerBitRes:
 
     def get_exact_prop(self) -> float:
         return self.exacts / self.all_cases
+
+
+class CaseExamples:
+    args: tuple[str, ...]
+    synth: str
+    best: str
+    dist: float
 
 
 class EvalResult:
@@ -75,6 +89,10 @@ class EvalResult:
     exacts: int
     unsolved_cases: int
     unsolved_exacts: int
+
+    # Example cases for unsound and imprecise transformers
+    unsound_examples: list[CaseExample]
+    imprecise_examples: list[CaseExample]
 
     @classmethod
     def init_bw_settings(
@@ -102,6 +120,14 @@ class EvalResult:
         self.exacts = sum(res.exacts for res in low_med_res)
         self.unsolved_cases = sum(res.unsolved_cases for res in low_med_res)
         self.unsolved_exacts = sum(res.unsolved_exacts for res in low_med_res)
+
+        # Aggregate unsound and imprecise examples from all bitwidths
+        self.unsound_examples = [
+            example for res in per_bit_res for example in res.unsound_examples
+        ]
+        self.imprecise_examples = [
+            example for res in per_bit_res for example in res.imprecise_examples
+        ]
 
     def __str__(self):
         def _pct(n: float, d: float) -> float:

--- a/synth_xfer/_util/eval_result.py
+++ b/synth_xfer/_util/eval_result.py
@@ -1,7 +1,20 @@
 from dataclasses import dataclass
+from typing import NamedTuple
 
-# Type alias for case examples: (inputs, output, optimal_output, distance)
-CaseExample = tuple[tuple[str, ...], str, str, float]
+
+class CaseExample(NamedTuple):
+    inputs: tuple[str, ...]
+    output: str
+    optimal: str
+    dist: float
+
+    def to_str(self, show_dist: bool = True) -> str:
+        inputs_str = f"({', '.join(self.inputs)})"
+        s = f"{inputs_str} -> {self.output} (best: {self.optimal}"
+        if show_dist:
+            s += f", dist: {self.dist:.4f}"
+        s += ")"
+        return s
 
 
 @dataclass
@@ -58,13 +71,6 @@ class PerBitRes:
 
     def get_exact_prop(self) -> float:
         return self.exacts / self.all_cases
-
-
-class CaseExamples:
-    args: tuple[str, ...]
-    synth: str
-    best: str
-    dist: float
 
 
 class EvalResult:

--- a/synth_xfer/cli/eval_final.py
+++ b/synth_xfer/cli/eval_final.py
@@ -329,6 +329,7 @@ def main() -> None:
         if exact_bw is not None:
             top_8 = next(x for x in top_r.per_bit_res if x.bitwidth == exact_bw)
             synth_8 = next(x for x in synth_r.per_bit_res if x.bitwidth == exact_bw)
+            row["Sound %"] = str(synth_8.get_sound_prop() * 100.0)
             row["Top Exact %"] = str(top_8.get_exact_prop() * 100.0)
             row["Synth Exact %"] = str(synth_8.get_exact_prop() * 100.0)
 

--- a/synth_xfer/cli/eval_final.py
+++ b/synth_xfer/cli/eval_final.py
@@ -68,6 +68,18 @@ def _reg_args():
     make_sampler_parser(p)
     p.add_argument("-o", "--output", type=Path, default=None)
     p.add_argument(
+        "--unsound-ex",
+        type=int,
+        default=0,
+        help="Maximum unsound examples to collect",
+    )
+    p.add_argument(
+        "--imprecise-ex",
+        type=int,
+        default=0,
+        help="Maximum imprecise examples to collect",
+    )
+    p.add_argument(
         "-d",
         "--domain",
         type=str,
@@ -139,6 +151,8 @@ def run(
     xfer_name: str,
     random_seed: int | None,
     sampler: Sampler,
+    unsound_ex: int = 0,
+    imprecise_ex: int = 0,
 ) -> tuple[EvalResult, EvalResult]:
     all_bws = lbw + [x[0] for x in mbw] + [x[0] for x in hbw]
     helpers = get_helper_funcs(op_path, domain)
@@ -170,7 +184,9 @@ def run(
             for bw in all_bws
         }
 
-        res = eval_transfer_func(eval_input)
+        res = eval_transfer_func(
+            eval_input, unsound_ex=unsound_ex, imprecise_ex=imprecise_ex
+        )
         assert len(res) == 2
 
         return (res[0], res[1])
@@ -184,6 +200,8 @@ class EvalJob:
     xfer_name: str
     random_seed: int | None
     bw_args: tuple[list[int], list[tuple[int, int]], list[tuple[int, int, int]]]
+    unsound_ex: int
+    imprecise_ex: int
     args: Namespace
 
 
@@ -200,6 +218,8 @@ def _run_job(job: EvalJob) -> tuple[EvalResult, EvalResult]:
         xfer_name=job.xfer_name,
         random_seed=job.random_seed,
         sampler=sampler,
+        unsound_ex=job.unsound_ex,
+        imprecise_ex=job.imprecise_ex,
     )
 
 
@@ -254,6 +274,8 @@ def _make_job(
     xfer_name: str,
     args: Namespace,
     bw_args: tuple[list[int], list[tuple[int, int]], list[tuple[int, int, int]]],
+    unsound_ex: int = 0,
+    imprecise_ex: int = 0,
 ) -> EvalJob:
     return EvalJob(
         domain=domain,
@@ -262,6 +284,8 @@ def _make_job(
         xfer_name=xfer_name,
         random_seed=args.random_seed,
         bw_args=bw_args,
+        unsound_ex=unsound_ex,
+        imprecise_ex=imprecise_ex,
         args=args,
     )
 
@@ -288,6 +312,8 @@ def main() -> None:
                     xfer_name=xfer_name,
                     args=args,
                     bw_args=bw_args,
+                    unsound_ex=args.unsound_ex,
+                    imprecise_ex=args.imprecise_ex,
                 )
             )
 
@@ -305,6 +331,8 @@ def main() -> None:
                 xfer_name=xfer_name,
                 args=args,
                 bw_args=bw_args,
+                unsound_ex=args.unsound_ex,
+                imprecise_ex=args.imprecise_ex,
             )
         ]
     else:
@@ -347,6 +375,28 @@ def main() -> None:
     print(df)
     if args.output:
         df.to_csv(args.output)
+
+    # Print unsound and imprecise examples for synthesized transformers on exact bitwidth
+    if exact_bw is not None:
+        for job, (top_r, synth_r) in zip(jobs, data):
+            synth_exact = next(x for x in synth_r.per_bit_res if x.bitwidth == exact_bw)
+            if synth_exact.unsound_examples:
+                print(f"\nUNSOUND EXAMPLES ({len(synth_exact.unsound_examples)}):")
+                for i, (inputs, output, optimal, dist) in enumerate(
+                    synth_exact.unsound_examples, 1
+                ):
+                    inputs_str = f"({', '.join(inputs)})"
+                    print(f"{inputs_str} -> {output} (optimal: {optimal})")
+
+            if synth_exact.imprecise_examples:
+                print(f"\nIMPRECISE EXAMPLES ({len(synth_exact.imprecise_examples)}):")
+                for i, (inputs, output, optimal, dist) in enumerate(
+                    synth_exact.imprecise_examples, 1
+                ):
+                    inputs_str = f"({', '.join(inputs)})"
+                    print(
+                        f"{inputs_str} -> {output} (optimal: {optimal}, dist: {dist:.4f})"
+                    )
 
 
 if __name__ == "__main__":

--- a/synth_xfer/cli/eval_final.py
+++ b/synth_xfer/cli/eval_final.py
@@ -382,19 +382,13 @@ def main() -> None:
             synth_exact = next(x for x in synth_r.per_bit_res if x.bitwidth == exact_bw)
             if synth_exact.unsound_examples:
                 print(f"\nUNSOUND EXAMPLES ({len(synth_exact.unsound_examples)}):")
-                for i, (inputs, output, optimal, dist) in enumerate(
-                    synth_exact.unsound_examples, 1
-                ):
-                    inputs_str = f"({', '.join(inputs)})"
-                    print(f"{inputs_str} -> {output} (best: {optimal})")
+                for ex in synth_exact.unsound_examples:
+                    print(ex.to_str(show_dist=False))
 
             if synth_exact.imprecise_examples:
                 print(f"\nIMPRECISE EXAMPLES ({len(synth_exact.imprecise_examples)}):")
-                for i, (inputs, output, optimal, dist) in enumerate(
-                    synth_exact.imprecise_examples, 1
-                ):
-                    inputs_str = f"({', '.join(inputs)})"
-                    print(f"{inputs_str} -> {output} (best: {optimal}, dist: {dist:.4f})")
+                for ex in synth_exact.imprecise_examples:
+                    print(ex.to_str())
 
 
 if __name__ == "__main__":

--- a/synth_xfer/cli/eval_final.py
+++ b/synth_xfer/cli/eval_final.py
@@ -386,7 +386,7 @@ def main() -> None:
                     synth_exact.unsound_examples, 1
                 ):
                     inputs_str = f"({', '.join(inputs)})"
-                    print(f"{inputs_str} -> {output} (optimal: {optimal})")
+                    print(f"{inputs_str} -> {output} (best: {optimal})")
 
             if synth_exact.imprecise_examples:
                 print(f"\nIMPRECISE EXAMPLES ({len(synth_exact.imprecise_examples)}):")
@@ -394,9 +394,7 @@ def main() -> None:
                     synth_exact.imprecise_examples, 1
                 ):
                     inputs_str = f"({', '.join(inputs)})"
-                    print(
-                        f"{inputs_str} -> {output} (optimal: {optimal}, dist: {dist:.4f})"
-                    )
+                    print(f"{inputs_str} -> {output} (best: {optimal}, dist: {dist:.4f})")
 
 
 if __name__ == "__main__":

--- a/synth_xfer/cli/verify.py
+++ b/synth_xfer/cli/verify.py
@@ -183,7 +183,7 @@ def _print_counterexample(
         try:
             abst_output = run_xfer_fn(
                 domain, bw, [tuple(abst_args)], mlir_mod, xfer_name
-            )[0]  # type: ignore
+            )[0]
         except ImportError as e:
             abst_output = None
             print(f"Warning: Could not execute due {e}")

--- a/synth_xfer/cli/verify.py
+++ b/synth_xfer/cli/verify.py
@@ -7,7 +7,7 @@ from xdsl.parser import ModuleOp
 from z3 import BitVecNumRef, FuncDeclRef, ModelRef
 
 from synth_xfer._util.domain import AbstractDomain
-from synth_xfer._util.eval import parse_to_run_inputs, run_concrete_fn
+from synth_xfer._util.eval import run_concrete_fn
 from synth_xfer._util.parse_mlir import (
     HelperFuncs,
     get_fns,


### PR DESCRIPTION
This PR mainly includes:
1. Let `eval-final` return a set of unsound/imprecise test cases. The number are set by `--unsound-ex` and `imprecise-ex`.
2. Let `eval-final` output soundness 

A test command:
```
eval-final tests/data/kb_or.mlir        \            
           --domain KnownBits            \  
           --op mlir/Operations/And.mlir \
           --exact-bw 8,1000             \
           --norm-bw none --unsound-ex 10 --imprecise-ex 5
```