### PR TITLE
add meet

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ You can omit `--dump-agent-run` if you don't need the full run dump.
 | `--model` | OpenAI model (default: `gpt-4`). See [OpenAI pricing](https://developers.openai.com/api/docs/pricing). |
 | `--skip-eval` | Skip running eval-final after synthesis. |
 | `--dump-agent-run` | Write a full dump of the agent run (messages, tool calls, token usage) to the output dir. |
+| `--rounds` | Number of library-update rounds; `0` = synthesis-only (default: `0`). |
+| `--meet` | Accumulate solutions across rounds into a `SolutionSet` and combine them via meet. |
+| `--no-learn` | Skip the library learning step after each synthesis round. |
 
 **Using `--benchmark` with a `bench.yaml` file:**
 
@@ -312,6 +315,31 @@ agent-synth --benchmark bench.yaml -o outputs/test-lib/ --model gpt-5.1-codex-mi
 Op names in `concrete_ops` are resolved to `mlir/Operations/{Name}.mlir` relative to the project root.
 
 Each run prints the **model** in use and **token usage** (input/output/reasoning and total). The agent is prompted to reason about the operation and KnownBits before writing MLIR and to use multiple turns to improve quality rather than stopping at the first candidate that passes eval.
+
+### Meet Mode
+
+`--meet` enables meet-combination across synthesis rounds: each round's best solution is accumulated into a `SolutionSet`, and the final result is the meet of all collected solutions. This typically yields a more precise transformer than any single round alone.
+
+`--no-learn` disables library learning between rounds, which is useful when you want to test meet-combination in isolation or when you don't yet have a library to update.
+
+Single-op run with meet mode and no library learning (fast test):
+```bash
+agent-synth mlir/Operations/Umax.mlir \
+    -o outputs/umax                   \
+    --model gpt-5.1-codex-mini        \
+    --rounds 3                        \
+    --meet                            \
+    --no-learn
+```
+
+Multi-op run with meet mode and library learning enabled:
+```bash
+agent-synth mlir/Operations/Umin.mlir mlir/Operations/Umax.mlir \
+    -o outputs/meet-test              \
+    --model gpt-5.1-codex-mini        \
+    --rounds 3                        \
+    --meet
+```
 
 ## Important CLI Options for `simplifier`
 

--- a/agent/agent_solution_set.py
+++ b/agent/agent_solution_set.py
@@ -1,0 +1,65 @@
+from agent.util import (
+    EvalArgs,
+    LibraryState,
+    _format_eval_examples_for_agent,
+    _get_xfer_name,
+    _run_eval,
+    rename_xfer,
+)
+from synth_xfer._util.eval_result import EvalResult
+
+
+class AgentSolutionSet:
+    """Lightweight solution set for use by the agent, operating on MLIR strings."""
+
+    solutions: list[str]
+    library: LibraryState
+    _base_result_cache: EvalResult | None
+
+    def __init__(self, library: LibraryState) -> None:
+        self.solutions = []
+        self.library = library
+        self._base_result_cache = None
+
+    @staticmethod
+    def _format_result(result: EvalResult) -> str:
+        return (
+            f"Sound %: {result.get_sound_prop() * 100:.2f}, "
+            f"Exact %: {result.get_exact_prop() * 100:.2f}, "
+            f"Dist: {result.sound_dist:.4f}"
+        )
+
+    def eval_improve(
+        self, new_sol: str, eval_args: EvalArgs, no_previous: bool = False
+    ) -> str:
+        """Evaluate new_sol against existing base solutions. Returns summary string."""
+        upd_result = _run_eval(
+            xfer=[new_sol],
+            base=self.solutions,
+            lib=[self.library.functions_text],
+            eval_args=eval_args,
+        )
+        upd_res = self._format_result(upd_result) + _format_eval_examples_for_agent(
+            upd_result, eval_args.domain
+        )
+        if no_previous:
+            return upd_res
+        base_res = self.eval_base(eval_args)
+        return f"Previous: {base_res}\n Updated: {upd_res}"
+
+    def eval_base(self, eval_args: EvalArgs) -> str:
+        """Evaluate existing solutions with top as the candidate. Returns summary string."""
+        if self._base_result_cache is None:
+            self._base_result_cache = _run_eval(
+                xfer=[],
+                base=self.solutions,
+                lib=[self.library.functions_text],
+                eval_args=eval_args,
+            )
+        return self._format_result(self._base_result_cache)
+
+    def upd_solution(self, new_sol: str) -> None:
+        old_name = _get_xfer_name(new_sol)
+        new_name = f"{old_name}_{len(self.solutions)}"
+        self.solutions += [rename_xfer(new_sol, new_name)]
+        self._base_result_cache = None

--- a/agent/args.py
+++ b/agent/args.py
@@ -6,6 +6,20 @@ from pathlib import Path
 import yaml
 
 
+def _parse_bw_pair(s: str) -> tuple[int, int]:
+    parts = [int(x.strip()) for x in s.split(",")]
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(f"Expected 'bw,samples', got: {s!r}")
+    return (parts[0], parts[1])
+
+
+def _parse_bw_triple(s: str) -> tuple[int, int, int]:
+    parts = [int(x.strip()) for x in s.split(",")]
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(f"Expected 'bw,lo,hi', got: {s!r}")
+    return (parts[0], parts[1], parts[2])
+
+
 def _load_ops_from_bench(bench_path: Path) -> list[str]:
     """Parse bench.yaml and return list of MLIR op file paths."""
     with bench_path.open() as f:
@@ -20,6 +34,7 @@ def _load_ops_from_bench(bench_path: Path) -> list[str]:
 def _validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     for name, path in [
         ("--agent-instructions", args.agent_instructions),
+        ("--meet-instructions", args.meet_instructions),
         ("--library-instructions", args.library_instructions),
         ("--compress-instructions", args.compress_instructions),
         ("--library-prompt", args.library_prompt),
@@ -92,6 +107,12 @@ def parse_args() -> argparse.Namespace:
         help="Path to agent instructions file (default: agent/md/agent_instructions.md)",
     )
     parser.add_argument(
+        "--meet-instructions",
+        type=Path,
+        default=Path(__file__).parent / "md" / "meet_instructions.md",
+        help="Path to agent instructions for meet mode (default: agent/md/meet_instructions.md)",
+    )
+    parser.add_argument(
         "--library-instructions",
         type=Path,
         default=Path(__file__).parent / "md" / "library_instructions.md",
@@ -158,14 +179,44 @@ def parse_args() -> argparse.Namespace:
         help="Skip the compress step after synthesis (default: compress is enabled)",
     )
     parser.add_argument(
-        "--exact-bw",
+        "--lbw",
         type=int,
-        nargs="+",
-        default=[8],
+        nargs="*",
+        default=[4],
         metavar="BW",
-        help="Exact bitwidth(s) for eval (default: 8)",
+        help="Low (exact) bitwidth(s) for eval (default: 4)",
     )
-
+    parser.add_argument(
+        "--mbw",
+        type=_parse_bw_pair,
+        nargs="*",
+        default=[(8, 10000)],
+        metavar="BW,SAMPLES",
+        help="Medium bitwidth(s) for eval as 'bw,samples' (default: 8,10000)",
+    )
+    parser.add_argument(
+        "--hbw",
+        type=_parse_bw_triple,
+        nargs="*",
+        default=[],
+        metavar="BW,LO,HI",
+        help="High bitwidth(s) for eval as 'bw,lo,hi' (default: none)",
+    )
+    parser.add_argument(
+        "--meet",
+        action="store_true",
+        help="Accumulate solutions into a SolutionSet and combine via meet",
+    )
+    parser.add_argument(
+        "--mock-synth",
+        action="store_true",
+        help="Skip synthesis agent; return a random example from examples_dir for fast pipeline testing",
+    )
+    parser.add_argument(
+        "--no-learn",
+        action="store_true",
+        help="Skip the library learning step after each synthesis round",
+    )
     args = parser.parse_args()
     _validate_args(parser, args)
     return args

--- a/agent/compress.py
+++ b/agent/compress.py
@@ -10,11 +10,11 @@ from synth_xfer._util.domain import AbstractDomain
 
 from .agent_helper import format_agent_run_dump
 from .util import (
+    EvalArgs,
     LibraryState,
     SynthesisResult,
     clean_llm_output,
     eval_transformer,
-    merge_library_text,
     print_token_usage,
     save_file,
 )
@@ -30,6 +30,8 @@ def _run_agent_compress(
     instructions_path: Path,
     max_turns: int,
     lbw: list[int],
+    mbw: list[int],
+    hbw: list[int],
 ) -> tuple[str, object]:
     """Run agent to compress a target file. Returns (final_output, run_result)."""
     del api_key  # Reserved for future model/provider auth parity.
@@ -89,13 +91,14 @@ def _run_agent_compress(
 
         # Get eval of current transformer
         if not target.eval_summary:
-            full_soln = merge_library_text(library.functions_text, target.solution_text)
             curr_eval_summary = eval_transformer(
-                solution=full_soln,
-                op_path=Path(target.task.op_file),
-                domain=AbstractDomain.KnownBits,
-                xfer_name=f"kb_{target.task.op_name.lower()}",
-                lbw=lbw,
+                [target.solution_text],
+                EvalArgs(
+                    op_path=Path(target.task.op_file),
+                    domain=AbstractDomain.KnownBits,
+                    lbw=lbw,
+                ),
+                lib=[func.source for func in library.functions],
             )
             match = re.search(pattern, curr_eval_summary)
             if match is None:
@@ -118,13 +121,14 @@ def _run_agent_compress(
             curr_exact = float(match.group("exact"))
 
         # Get eval of new transformer
-        full_soln = merge_library_text(library.functions_text, transformer_mlir)
         compressed_eval_summary = eval_transformer(
-            solution=full_soln,
-            op_path=Path(target.task.op_file),
-            domain=AbstractDomain.KnownBits,
-            xfer_name=f"kb_{target.task.op_name.lower()}",
-            lbw=lbw,
+            [transformer_mlir],
+            EvalArgs(
+                op_path=Path(target.task.op_file),
+                domain=AbstractDomain.KnownBits,
+                lbw=lbw,
+            ),
+            lib=[func.source for func in library.functions],
         )
         match = re.search(pattern, compressed_eval_summary)
         if match is None:
@@ -193,7 +197,9 @@ def run_compress_task(
         ops_path=args.ops,
         instructions_path=args.compress_instructions,
         max_turns=args.max_turns,
-        lbw=args.exact_bw,
+        lbw=args.lbw,
+        mbw=args.mbw,
+        hbw=args.hbw,
     )
     print_token_usage(run_result)
 

--- a/agent/examples/kb_top.mlir
+++ b/agent/examples/kb_top.mlir
@@ -1,0 +1,6 @@
+func.func @kb_top(%lhs : !transfer.abs_value<[!transfer.integer, !transfer.integer]>, %rhs : !transfer.abs_value<[!transfer.integer, !transfer.integer]>) -> !transfer.abs_value<[!transfer.integer, !transfer.integer]> {
+    %lhs0 = "transfer.get"(%lhs) {index = 0} : (!transfer.abs_value<[!transfer.integer, !transfer.integer]>) -> !transfer.integer
+    %const0 = "transfer.constant"(%lhs_zero) {value = 0 : index} : (!transfer.integer) -> !transfer.integer
+    %r = "transfer.make"(%const0, %const0) : (!transfer.integer, !transfer.integer) -> !transfer.abs_value<[!transfer.integer, !transfer.integer]>
+    func.return %r : !transfer.abs_value<[!transfer.integer, !transfer.integer]>
+  }

--- a/agent/main.py
+++ b/agent/main.py
@@ -3,6 +3,7 @@
 
 import asyncio
 from pathlib import Path
+import re
 import sys
 
 from .args import parse_args
@@ -17,6 +18,14 @@ from .util import (
     get_api_key,
     load_initial_library,
 )
+
+
+def _is_fully_sound(eval_summary: str | None) -> bool:
+    """Return True if eval_summary reports Sound % = 100."""
+    if not eval_summary:
+        return False
+    m = re.search(r"Sound %:\s*([\d.]+)", eval_summary)
+    return m is not None and float(m.group(1)) == 100.0
 
 
 def run_library_learning_loop(
@@ -43,7 +52,16 @@ def run_library_learning_loop(
         latest_results = asyncio.run(
             run_synthesis_tasks(synth_agents, tasks, round_idx, library, args)
         )
-        if round_idx < num_rounds:
+        if args.meet:
+            for result in latest_results:
+                if result.solution_text != "NO_IMPROVEMENT" and _is_fully_sound(
+                    result.eval_summary
+                ):
+                    agent = synth_agents[result.task.op_name]
+                    agent.solution_set.upd_solution(result.solution_text)
+
+        # Xuanyu: maybe when meet is enabled, not only the latest solution but the entire solution set should be sent to the library learning.
+        if round_idx < num_rounds and not args.no_learn:
             library = run_library_learn_task(
                 version=round_idx + 1,
                 previous_library=library,

--- a/agent/md/agent_instructions.md
+++ b/agent/md/agent_instructions.md
@@ -4,18 +4,22 @@ Use tools to fetch all materials; do not assume they are in this message:
 - get_task_bundle(): concrete op MLIR
 - get_program_templates(): output templates
 - get_available_primitives(): allowed operators
-- list_library_functions()/search_library_functions()/get_library_function(): search and retrieve available library functions
+- list_library_functions()/get_library_function(): retrieve available library functions
 - list_examples()/search_examples()/get_example(): reference implementations
-- run_eval_tool(mlir): evaluate your candidate
+The most important tool is run_eval_tool(mlir): evaluate your candidate.
+If your result is unsound or imprecise, it will provide examples of unsound or imprecise cases.
+Make liberal use of this tool — eval early and eval often. Do not wait until you think your solution is complete; use it to check intermediate candidates as well.
 
-- Before writing any MLIR: reason step-by-step about the operation semantics and how each output bit should update known-zero and known-one. Aim for a sound and precise transfer, not just the first candidate that passes eval.
-- Prioritize reusing functions from the library — they are mined from previous rounds and can potentially shorten your solution significantly.
-- You must call the eval tool with your MLIR before returning. If it returns an error (e.g. parse error), fix the MLIR and call again.
-- If eval returns unsound (Sound % < 100), you must fix the soundness and should not return yet.
-- If eval returns sound but low precision (Sound % = 100 and Exact % is low), reason about why (e.g. missing cases, wrong bit propagation) and try a better design before submitting the next candidate; do not only make minimal syntax fixes.
+Workflow:
+- Before writing any MLIR: reason step-by-step about the operation semantics and how each output bit should update known-zero and known-one. Predict what the transfer function should look like before writing it.
+- If the library is not empty, reusing library functions is your first priority — call list_library_functions() at the start and check for functions that match or closely approximate the operation before writing anything from scratch. Library functions are mined from previous rounds and can significantly shorten your solution.
+- Make an initial prediction of your solution, then immediately call run_eval_tool to test it. Use the feedback to iterate.
+- You must call run_eval_tool with your MLIR before returning. If it returns an error (e.g. parse error), fix the MLIR and call again.
+- If run_eval_tool returns unsound (Sound % < 100), you must fix the soundness and should not return yet.
+- If run_eval_tool returns sound but low precision (Sound % = 100 and Exact % is low), reason about why (e.g. missing cases, wrong bit propagation) and try a better design before submitting the next candidate; do not only make minimal syntax fixes.
 - Only when the tool returns sound (Sound % = 100) and you are satisfied with the precision (Exact % is high), return that MLIR as your final answer. Prefer a well-reasoned, precise implementation over stopping at the first passing candidate.
-- Each line of MLIR must be exactly one operation from the allowed ops; do not write alias assignments like `%x = %y : !transfer.integer`
 
 Output contract:
 - Return ONLY MLIR func.func @kb_<op>
 - One operation per line; SSA form; no explanations.
+- Each line of MLIR must be exactly one operation from the allowed ops; do not write alias assignments like `%x = %y : !transfer.integer`

--- a/agent/md/meet_instructions.md
+++ b/agent/md/meet_instructions.md
@@ -1,0 +1,29 @@
+You synthesize KnownBits transfer functions in MLIR for operation <OP> (file: <OP_FILE>).
+
+You are running in **meet mode**: your candidate will be combined with all previously accepted solutions via the meet operator. You do not need to cover every input — focus on inputs that existing solutions miss. A candidate that is sound globally and precise on a new subset of inputs will improve the collective solution set even if it is imprecise elsewhere.
+
+Use tools to fetch all materials; do not assume they are in this message:
+- get_task_bundle(): concrete op MLIR
+- get_program_templates(): output templates
+- get_available_primitives(): allowed operators
+- list_examples()/search_examples()/get_example(): reference implementations
+- list_library_functions()/get_library_function(): retrieve available library functions
+- get_existing_solutions(): view the MLIR of all solutions already in the solution set
+- run_eval_improve(mlir): evaluate your candidate combined with existing solutions via meet; returns two lines — "Previous" (current solution set) and "Updated" (after adding your candidate)
+
+Make liberal use of run_eval_improve — eval early and eval often. Do not wait until you think your solution is complete; use it to check partial ideas and intermediate candidates as well.
+
+Workflow:
+- If the library is not empty, reusing library functions is your first priority — call list_library_functions() at the start and check for functions that match or closely approximate the operation before writing anything from scratch. Library functions are mined from previous rounds and can significantly shorten your solution.
+- Call get_existing_solutions() to see what is already covered, then reason step-by-step about which inputs the current solution set handles imprecisely. Predict what a candidate that covers those inputs should look like.
+- Make an initial prediction of your candidate, then immediately call run_eval_improve to test it. Use the feedback to iterate.
+- You must call run_eval_improve with your MLIR before returning. If it returns an error (e.g. parse error), fix the MLIR and call again.
+- If the Updated line shows Sound % < 100, you must fix the soundness issue and call eval again before returning.
+- If the Updated line shows Sound % = 100 and Exact % is higher than the Previous line, you have made a valid improvement and may return. You may also continue iterating to improve precision further if you see room for it.
+- Do not return a candidate that does not improve Exact % (or lower Dist) compared to the Previous line.
+
+
+Output contract:
+- Return ONLY MLIR func.func @kb_<op>. Do not wrap it in a module.
+- One operation per line; SSA form; no explanations.
+- Each line of MLIR must be exactly one operation from the allowed ops; do not write alias assignments like `%x = %y : !transfer.integer`

--- a/agent/synth.py
+++ b/agent/synth.py
@@ -8,16 +8,17 @@ from typing import Any
 
 from agents import Agent, Runner, function_tool
 
+from agent.agent_solution_set import AgentSolutionSet
 from synth_xfer._util.domain import AbstractDomain
 
 from .agent_helper import format_agent_run_dump
 from .util import (
+    EvalArgs,
     LibraryState,
     SynthesisResult,
     SynthesisTask,
     clean_llm_output,
     eval_transformer,
-    merge_library_text,
     print_token_usage,
     save_file,
 )
@@ -55,6 +56,7 @@ class SynthesisAgent:
         self._history: list[Any] | None = None
         self._soln_iters: list[str] = []
         self._agent = self._build_agent(args, api_key)
+        self.solution_set = AgentSolutionSet(current_lib)
 
     def update_library(self, new_lib: LibraryState) -> None:
         """Update the library used by this agent's tools."""
@@ -66,11 +68,14 @@ class SynthesisAgent:
         template_path: Path = args.template
         ops_path: Path = args.ops
         examples_dir: Path = args.examples_dir
-        instructions_path: Path = args.agent_instructions
+        instructions_path: Path = (
+            args.meet_instructions if args.meet else args.agent_instructions
+        )
 
         @function_tool
         def get_task_bundle() -> str:
             """Return the concrete operation/task bundle as JSON (op_name, op_file, and op_content)."""
+            print(f"[{task.op_name.upper()}] [TOOL] get_task_bundle", flush=True)
             op_path = Path(task.op_file)
             bundle = {
                 "op_name": task.op_name,
@@ -82,16 +87,19 @@ class SynthesisAgent:
         @function_tool
         def get_program_templates() -> str:
             """Return the MLIR output templates (agent/template.mlir)."""
+            print(f"[{task.op_name.upper()}] [TOOL] get_program_templates", flush=True)
             return template_path.read_text(encoding="utf-8")
 
         @function_tool
         def get_available_primitives() -> str:
             """Return the allowed primitive operators documentation (agent/ops.md)."""
+            print(f"[{task.op_name.upper()}] [TOOL] get_available_primitives", flush=True)
             return ops_path.read_text(encoding="utf-8")
 
         @function_tool
         def list_library_functions() -> str:
             """List available library functions as JSON dictionary of func names and docstrings"""
+            print(f"[{task.op_name.upper()}] [TOOL] list_library_functions", flush=True)
             funcs = {
                 func.function_name: func.docstring for func in self._library.functions
             }
@@ -100,6 +108,10 @@ class SynthesisAgent:
         @function_tool
         def get_library_function(name: str) -> str:
             """Return the source of a function by its name"""
+            print(
+                f"[{task.op_name.upper()}] [TOOL] get_library_function: {name!r}",
+                flush=True,
+            )
             for func in self._library.functions:
                 if func.function_name == name:
                     return func.source
@@ -109,6 +121,11 @@ class SynthesisAgent:
         @function_tool
         def search_library_functions(query: str, top_k: int = 3) -> str:
             """Search inside library functions by substring 'query' to understand how specific operators are used. Returns JSON array of matches with function name and docstring."""
+            # Xuanyu: I am not sure whether this tool is actually useful, since search_examples show usage of operators.
+            print(
+                f"[{task.op_name.upper()}] [TOOL] search_library_functions: {query!r}",
+                flush=True,
+            )
             if top_k <= 0:
                 return "[]"
             q = query.strip()
@@ -132,6 +149,7 @@ class SynthesisAgent:
         @function_tool
         def list_examples() -> str:
             """List available example transformer files as JSON array of filenames."""
+            print(f"[{task.op_name.upper()}] [TOOL] list_examples", flush=True)
             names = (
                 [p.name for p in sorted(examples_dir.glob("*.mlir"))]
                 if examples_dir.exists()
@@ -142,6 +160,7 @@ class SynthesisAgent:
         @function_tool
         def get_example(name: str) -> str:
             """Return the contents of one example transformer file by filename (e.g. 'kb_xor.mlir')."""
+            print(f"[{task.op_name.upper()}] [TOOL] get_example: {name!r}", flush=True)
             p = (examples_dir / name).resolve()
             ex_dir = examples_dir.resolve()
             if ex_dir not in p.parents:
@@ -155,6 +174,9 @@ class SynthesisAgent:
         @function_tool
         def search_examples(query: str, top_k: int = 3) -> str:
             """Search inside reference implementations by substring 'query' to understand the usage of operators. Returns JSON array of matches with filename and snippet."""
+            print(
+                f"[{task.op_name.upper()}] [TOOL] search_examples: {query!r}", flush=True
+            )
             if top_k <= 0:
                 return "[]"
             q = query.strip()
@@ -191,18 +213,70 @@ class SynthesisAgent:
 
             If the transformer is not fully sound or not fully exact, following lines may include a short legend and up to a few concrete counterexamples per bitwidth (unsound vs imprecise), labeled with bw=..., so you can see inputs, your abstract output, and the optimal abstract output.
             """
+            print(f"[{task.op_name.upper()}] [TOOL] run_eval_tool", flush=True)
             self._soln_iters.append(transformer_mlir)
-            lib_text = "\n".join(func.source for func in self._library.functions)
-            full_soln = merge_library_text(lib_text, transformer_mlir)
-            return eval_transformer(
-                solution=full_soln,
-                op_path=Path(task.op_file),
-                domain=AbstractDomain.KnownBits,
-                xfer_name=f"kb_{task.op_name.lower()}",
-                lbw=args.exact_bw,
-                unsound_ex=3,
-                imprecise_ex=3,
+            result = eval_transformer(
+                [transformer_mlir],
+                EvalArgs(
+                    op_path=Path(task.op_file),
+                    domain=AbstractDomain.KnownBits,
+                    lbw=args.lbw,
+                    mbw=args.mbw,
+                    hbw=args.hbw,
+                    unsound_ex=0,
+                    imprecise_ex=0,
+                ),
+                lib=[func.source for func in self._library.functions],
             )
+            print(
+                f"[{task.op_name.upper()}] [TOOL] run_eval_tool result:\n{result}",
+                flush=True,
+            )
+            return result
+
+        @function_tool
+        def get_existing_solutions() -> str:
+            """Return the MLIR source of all solutions currently in the solution set. Each solution will be combined with your candidate via meet when eval_improve is called. Use this to understand what cases are already covered before writing a new candidate."""
+            print(f"[{task.op_name.upper()}] [TOOL] get_existing_solutions", flush=True)
+            if not self.solution_set.solutions:
+                return "No solutions in the solution set yet."
+            return "\n\n".join(self.solution_set.solutions)
+
+        @function_tool
+        def run_eval_improve(transformer_mlir: str) -> str:
+            """Evaluate the transformer MLIR combined with all previously accepted solutions via meet. Returns two summary lines so you can compare before and after:
+
+            Previous: Sound/Exact/Dist of the existing solution set alone
+            Updated:  Sound/Exact/Dist after adding your candidate via meet
+
+            Each line has the format: Sound %: ..., Exact %: ..., Dist: ...
+            An improvement shows higher Exact % or lower Dist on the Updated line.
+
+            If the combined transformer is not fully sound or not fully precise, following lines may includeshort legend and up to a few concrete counterexamples per bitwidth (unsound vs imprecise labeled with bw=..., so you can see inputs, your abstract output, and the optimal abstract output.
+            """
+
+            print(f"[{task.op_name.upper()}] [TOOL] run_eval_improve:", flush=True)
+            try:
+                result = self.solution_set.eval_improve(
+                    transformer_mlir,
+                    EvalArgs(
+                        op_path=Path(task.op_file),
+                        domain=AbstractDomain.KnownBits,
+                        lbw=args.lbw,
+                        mbw=args.mbw,
+                        hbw=args.hbw,
+                        unsound_ex=5,
+                        imprecise_ex=5,
+                    ),
+                )
+            except Exception as e:
+                msg = str(e).strip() or repr(e) or type(e).__name__
+                result = f"error: {' '.join(msg.splitlines())[:1500]}"
+            print(
+                f"[{task.op_name.upper()}] [TOOL] run_eval_improve result:\n{result}",
+                flush=True,
+            )
+            return result
 
         return Agent(
             name="TransformerSynthesizer",
@@ -215,13 +289,16 @@ class SynthesisAgent:
                 get_task_bundle,
                 get_program_templates,
                 get_available_primitives,
-                list_library_functions,
-                get_library_function,
-                search_library_functions,
                 list_examples,
                 get_example,
                 search_examples,
-                run_eval_tool,
+                list_library_functions,
+                get_library_function,
+                *(
+                    [get_existing_solutions, run_eval_improve]
+                    if args.meet
+                    else [run_eval_tool]
+                ),
             ],
             model=args.model,
         )
@@ -248,26 +325,6 @@ class SynthesisAgent:
         return result.final_output, result, inp, list(self._soln_iters)
 
 
-def run_eval(
-    op_file_path: str,
-    transformer: SynthesisResult,
-    library: LibraryState,
-    op_name: str,
-    lbw: list[int],
-) -> str:
-    """Evaluate the transformer via eval_transformer (no subprocess)."""
-    cleaned_mlir = clean_llm_output(transformer.solution_text)
-    full_soln = merge_library_text(library.functions_text, cleaned_mlir)
-
-    return eval_transformer(
-        full_soln,
-        Path(op_file_path),
-        AbstractDomain.KnownBits,
-        f"kb_{op_name.lower()}",
-        lbw=lbw,
-    )
-
-
 async def run_single_synthesis_task(
     synth_agent: SynthesisAgent,
     task: SynthesisTask,
@@ -280,31 +337,50 @@ async def run_single_synthesis_task(
     print(f"{tag} Synthesizing: round={round_num}, op={task.op_name}")
 
     output_dir = Path(args.output)
-    print(f"{tag} Using model: {args.model}")
-    t0 = time.monotonic()
-    llm_output, run_result, agent_input, soln_iters = await synth_agent.run(round_num)
-    synthesis_time = time.monotonic() - t0
 
-    if args.dump_agent_run:
-        input_dump = (
-            agent_input
-            if isinstance(agent_input, str)
-            else json.dumps(agent_input, indent=2)
-        )
-        input_path = save_file(
-            input_dump,
-            output_dir,
-            f"synth_input_r{round_num}_{task.op_name.lower()}.json",
-        )
-        print(f"{tag} Agent input dump: {input_path}")
-        dump_path = save_file(
-            format_agent_run_dump(run_result),
-            output_dir,
-            f"synth_agent_r{round_num}_{task.op_name.lower()}.log",
-        )
-        print(f"{tag} Agent run dump: {dump_path}")
+    run_result = None
+    agent_input = None
+    soln_iters: list[str] = []
+    synthesis_time = 0.0
+    if args.mock_synth:
+        llm_output = (Path(__file__).parent / "examples" / "kb_top.mlir").read_text()
+    else:
+        print(f"{tag} Using model: {args.model}")
+        t0 = time.monotonic()
+        llm_output, run_result, agent_input, soln_iters = await synth_agent.run(round_num)
+        synthesis_time = time.monotonic() - t0
 
-    print_token_usage(run_result)
+    if not args.mock_synth:
+        if args.dump_agent_run:
+            input_dump = (
+                agent_input
+                if isinstance(agent_input, str)
+                else json.dumps(agent_input, indent=2)
+            )
+            input_path = save_file(
+                input_dump,
+                output_dir,
+                f"synth_input_r{round_num}_{task.op_name.lower()}.json",
+            )
+            print(f"{tag} Agent input dump: {input_path}")
+            dump_path = save_file(
+                format_agent_run_dump(run_result),
+                output_dir,
+                f"synth_agent_r{round_num}_{task.op_name.lower()}.log",
+            )
+            print(f"{tag} Agent run dump: {dump_path}")
+
+        print_token_usage(run_result)
+
+    if args.meet and llm_output.strip() == "NO_IMPROVEMENT":
+        print(f"{tag} No improvement found, skipping solution update.")
+        return SynthesisResult(
+            task=task,
+            solution_text="NO_IMPROVEMENT",
+            solution_iters=soln_iters,
+            transformer_path=Path(),
+        )
+
     transformer_file = save_file(
         clean_llm_output(llm_output),
         output_dir,
@@ -312,21 +388,36 @@ async def run_single_synthesis_task(
     )
     print(f"{tag} Transformer: {transformer_file}")
 
-    result = SynthesisResult(
-        task=task,
-        solution_text=llm_output,
-        solution_iters=soln_iters,
-        transformer_path=transformer_file,
-        eval_summary=None,
-    )
+    solution_text = clean_llm_output(llm_output)
 
     eval_summary: str | None = None
     if not args.skip_eval:
         print(f"{tag} Evaluating transformer...")
         eval_t0 = time.monotonic()
-        eval_summary = run_eval(
-            task.op_file, result, library, task.op_name, lbw=args.exact_bw
-        )
+        if args.meet:
+            eval_summary = synth_agent.solution_set.eval_improve(
+                solution_text,
+                EvalArgs(
+                    op_path=Path(task.op_file),
+                    domain=AbstractDomain.KnownBits,
+                    lbw=args.lbw,
+                    mbw=args.mbw,
+                    hbw=args.hbw,
+                ),
+                no_previous=True,
+            )
+        else:
+            eval_summary = eval_transformer(
+                [solution_text],
+                EvalArgs(
+                    op_path=Path(task.op_file),
+                    domain=AbstractDomain.KnownBits,
+                    lbw=args.lbw,
+                    mbw=args.mbw,
+                    hbw=args.hbw,
+                ),
+                lib=[func.source for func in library.functions],
+            )
         eval_time = time.monotonic() - eval_t0
         print(f"{tag} Eval result: {eval_summary}")
         save_file(
@@ -337,7 +428,7 @@ async def run_single_synthesis_task(
 
     return SynthesisResult(
         task=task,
-        solution_text=llm_output,
+        solution_text=solution_text,
         solution_iters=soln_iters,
         transformer_path=transformer_file,
         eval_summary=eval_summary,

--- a/agent/util.py
+++ b/agent/util.py
@@ -1,6 +1,6 @@
 """Agent utilities."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 from pathlib import Path
 import re
@@ -12,8 +12,21 @@ from synth_xfer._util.eval import enum, eval_transfer_func
 from synth_xfer._util.eval_result import EvalResult
 from synth_xfer._util.jit import Jit
 from synth_xfer._util.lower import LowerToLLVM
-from synth_xfer._util.parse_mlir import get_helper_funcs, parse_mlir_mod
+from synth_xfer._util.parse_mlir import get_helper_funcs, parse_mlir_mod, top_as_xfer
 from synth_xfer._util.random import Random, Sampler
+
+
+@dataclass
+class EvalArgs:
+    """Arguments for evaluating a transfer function."""
+
+    op_path: Path
+    domain: AbstractDomain
+    lbw: list[int]
+    mbw: list[tuple[int, int]] = field(default_factory=list)
+    hbw: list[tuple[int, int, int]] = field(default_factory=list)
+    unsound_ex: int = 0
+    imprecise_ex: int = 0
 
 
 @dataclass
@@ -270,58 +283,96 @@ def _format_eval_examples_for_agent(
     return "\n".join(lines).rstrip("\n")
 
 
+def _get_xfer_name(solution: str) -> str:
+    """Extract the first func.func name from an MLIR solution string."""
+    match = re.search(r"func\.func\s+@(\w+)\s*\(", solution)
+    if not match:
+        raise ValueError("No func.func definition found in solution")
+    return match.group(1)
+
+
+def rename_xfer(solution: str, new_name: str) -> str:
+    """Rename the transfer function in an MLIR solution string."""
+    old_name = _get_xfer_name(solution)
+    return re.sub(rf"@{re.escape(old_name)}\b", f"@{new_name}", solution)
+
+
+def _run_eval(
+    xfer: list[str],
+    base: list[str],
+    lib: list[str],
+    eval_args: EvalArgs,
+) -> EvalResult:
+    """Core eval logic shared by eval_transformer and AgentSolutionSet.
+
+    xfer: candidate transfer function(s); empty list uses top as candidate.
+    base: existing solutions combined via meet for comparison.
+    lib:  library helper functions.
+    """
+    lbw, mbw, hbw = eval_args.lbw, eval_args.mbw, eval_args.hbw
+    all_bws = lbw + [x[0] for x in mbw] + [x[0] for x in hbw]
+    EvalResult.init_bw_settings(set(lbw), set(x[0] for x in mbw), set(x[0] for x in hbw))
+    sampler = Sampler.uniform()
+
+    base_names = [_get_xfer_name(s) for s in base]
+    helpers = get_helper_funcs(eval_args.op_path, eval_args.domain)
+    seed = Random(None).randint(0, 1_000_000)
+
+    combined = ""
+    for p in lib + base + xfer:
+        if p.strip():
+            combined = merge_library_text(combined, p)
+
+    lowerer = LowerToLLVM(all_bws)
+    lowerer.add_fn(helpers.meet_func)
+    lowerer.add_fn(helpers.get_top_func)
+
+    if xfer:
+        xfer_name = _get_xfer_name(xfer[0])
+        lowerer.add_mod(parse_mlir_mod(combined), [xfer_name] + base_names)
+        cand_shim_names = {bw: f"{xfer_name}_{bw}_shim" for bw in all_bws}
+    else:
+        top_bw_fns = lowerer.add_fn(top_as_xfer(helpers.transfer_func), shim=True)
+        cand_shim_names = {bw: fn.name for bw, fn in top_bw_fns.items()}
+        if combined:
+            lowerer.add_mod(parse_mlir_mod(combined), base_names)
+
+    to_eval = enum(lbw, mbw, hbw, seed, helpers, sampler)
+    with Jit() as jit:
+        jit.add_mod(lowerer)
+        eval_input = {
+            bw: (
+                to_eval[bw],
+                [jit.get_fn_ptr(cand_shim_names[bw])],
+                [jit.get_fn_ptr(f"{bn}_{bw}_shim") for bn in base_names],
+            )
+            for bw in all_bws
+        }
+        (result,) = eval_transfer_func(
+            eval_input, eval_args.unsound_ex, eval_args.imprecise_ex
+        )
+
+    return result
+
+
 def eval_transformer(
-    solution: str,
-    op_path: Path,
-    domain: AbstractDomain,
-    xfer_name: str,
+    xfer: list[str],
+    eval_args: EvalArgs,
     *,
-    lbw: list[int],
-    mbw: list[tuple[int, int]] = [],
-    hbw: list[tuple[int, int, int]] = [],
-    random_seed: int | None = None,
-    unsound_ex: int = 0,
-    imprecise_ex: int = 0,
+    lib: list[str] = [],
 ) -> str:
     """Run eval on a transformer (MLIR string) and return a summary string.
 
     For use by the agent and by main.run_eval(). On failure returns 'error: ...'.
     """
     try:
-        all_bws = lbw + [x[0] for x in mbw] + [x[0] for x in hbw]
-        EvalResult.init_bw_settings(
-            set(lbw), set(x[0] for x in mbw), set(x[0] for x in hbw)
-        )
-        sampler = Sampler.uniform()
-
-        helpers = get_helper_funcs(op_path, domain)
-        sol_module = parse_mlir_mod(solution)
-        seed = (
-            Random(random_seed).randint(0, 1_000_000)
-            if random_seed is None
-            else random_seed
-        )
-
-        lowerer = LowerToLLVM(all_bws)
-        lowerer.add_fn(helpers.meet_func)
-        lowerer.add_fn(helpers.get_top_func)
-        lowerer.add_mod(sol_module, [xfer_name])
-
-        to_eval = enum(lbw, mbw, hbw, seed, helpers, sampler)
-        with Jit() as jit:
-            jit.add_mod(lowerer)
-            eval_input = {
-                bw: (to_eval[bw], [jit.get_fn_ptr(f"{xfer_name}_{bw}_shim")], [])
-                for bw in all_bws
-            }
-            (synth_r,) = eval_transfer_func(eval_input, unsound_ex, imprecise_ex)
-
+        result = _run_eval(xfer, [], lib, eval_args)
         summary = (
-            f"Sound %: {synth_r.get_sound_prop() * 100:.2f}, "
-            f"Exact %: {synth_r.get_exact_prop() * 100:.2f}, "
-            f"Dist: {synth_r.sound_dist:.4f}"
+            f"Sound %: {result.get_sound_prop() * 100:.2f}, "
+            f"Exact %: {result.get_exact_prop() * 100:.2f}, "
+            f"Dist: {result.sound_dist:.4f}"
         )
-        return summary + _format_eval_examples_for_agent(synth_r, domain)
+        return summary + _format_eval_examples_for_agent(result, eval_args.domain)
     except Exception as e:
         msg = str(e).strip() or repr(e) or type(e).__name__
         # Single line, truncated, so the agent reliably sees parse/location info


### PR DESCRIPTION
Sorry this is a big PR

- **Add `meet` mode**: accumulates solutions across synthesis rounds into a `AgentSolutionSet` and combines them via meet, with dedicated `--meet` flag and `meet_instructions.md` prompt
- **Replace `--exact-bw`/`--dist-bw` with `--lbw`/`--mbw`/`--hbw`**
- **Add `--mock-synth`**: bypasses the synthesis agent and returns a random example from `examples_dir` for fast end-to-end pipeline testing
- **Add `--no-learn`**: skips the library learning step after each synthesis round
