### PR TITLE
Tune meet

### DIFF
--- a/agent/agent_helper.py
+++ b/agent/agent_helper.py
@@ -8,6 +8,8 @@ from agents.items import (
     ToolCallOutputItem,
 )
 
+from .util import summarize_token_usage
+
 # Helper stuff for debugging
 
 
@@ -26,9 +28,15 @@ def _format_tool_call_args(args) -> str:
     return args if isinstance(args, str) else str(args)
 
 
-def format_agent_run_dump(result) -> str:
+def format_agent_run_dump(result, model: str | None = None) -> str:
     """Format a RunResult into a readable dump of the full agent run (messages, tool calls, outputs)."""
-    lines: list[str] = ["=== Agent run dump ===", ""]
+    token_summary = summarize_token_usage(result, model=model)
+    lines: list[str] = [
+        "=== Agent run dump ===",
+        "",
+        str(token_summary),
+        "",
+    ]
 
     for i, item in enumerate(result.new_items):
         lines.append(

--- a/agent/agent_solution_set.py
+++ b/agent/agent_solution_set.py
@@ -30,21 +30,28 @@ class AgentSolutionSet:
 
     def eval_improve(
         self, new_sol: str, eval_args: EvalArgs, no_previous: bool = False
-    ) -> str:
-        """Evaluate new_sol against existing base solutions. Returns summary string."""
-        upd_result = _run_eval(
-            xfer=[new_sol],
-            base=self.solutions,
-            lib=[self.library.functions_text],
-            eval_args=eval_args,
-        )
-        upd_res = format_result(upd_result) + _format_eval_examples_for_agent(
-            upd_result, eval_args.domain
-        )
-        if no_previous:
-            return upd_res
-        base_res = self.eval_base(eval_args)
-        return f"Previous: {base_res}\n Updated: {upd_res}"
+    ) -> tuple[str, EvalResult | None]:
+        """Evaluate new_sol against existing base solutions.
+        Returns:
+            (summary, upd_result) where summary is the formatted comparison text.
+        """
+        try:
+            upd_result = _run_eval(
+                xfer=[new_sol],
+                base=self.solutions,
+                lib=[self.library.functions_text],
+                eval_args=eval_args,
+            )
+            upd_res = format_result(upd_result) + _format_eval_examples_for_agent(
+                upd_result, eval_args.domain
+            )
+            if no_previous:
+                return upd_res, upd_result
+            base_res = self.eval_base(eval_args)
+            return f"Previous: {base_res}\n Updated: {upd_res}", upd_result
+        except Exception as e:
+            msg = str(e).strip() or repr(e) or type(e).__name__
+            return f"error: {' '.join(msg.splitlines())[:1500]}", None
 
     def eval_base(self, eval_args: EvalArgs) -> str:
         """Evaluate existing solutions with top as the candidate. Returns summary string."""

--- a/agent/compress.py
+++ b/agent/compress.py
@@ -13,8 +13,9 @@ from .util import (
     SynthesisResult,
     clean_llm_output,
     eval_transformer,
-    print_token_usage,
+    get_op_output_dir,
     save_file,
+    summarize_token_usage,
 )
 
 
@@ -143,6 +144,7 @@ def run_compress_task(
     prompt = args.compress_prompt.read_text()
 
     output_dir = Path(args.output)
+    op_output_dir = get_op_output_dir(output_dir, op_name)
     print(f"Using model: {args.library_model}")
 
     llm_output, run_result = _run_agent_compress(
@@ -156,21 +158,22 @@ def run_compress_task(
         max_turns=args.max_turns,
         eval_args=eval_args,
     )
-    print_token_usage(run_result)
+    summary = summarize_token_usage(run_result, model=args.library_model)
+    print(summary)
 
     target_text = clean_llm_output(llm_output)
 
     if args.dump_agent_run:
         dump_path = save_file(
-            format_agent_run_dump(run_result),
-            output_dir,
+            format_agent_run_dump(run_result, model=args.library_model),
+            op_output_dir,
             f"compress_run{round_num}_{op_name}.log",
         )
         print(f"Agent run dump: {dump_path}")
 
     transformer_file = save_file(
         target_text,
-        output_dir,
+        op_output_dir,
         f"kb_r{round_num}_{op_name}_compressed.mlir",
     )
     print(f"Transformer: {transformer_file}")

--- a/agent/learn.py
+++ b/agent/learn.py
@@ -20,8 +20,8 @@ from .util import (
     extract_op_name,
     get_api_key,
     load_initial_library,
-    print_token_usage,
     save_file,
+    summarize_token_usage,
 )
 
 
@@ -241,7 +241,7 @@ def run_stitch_learn(
         )
         new_lib_funcs.append(lib_func)
         agent_log += f"\n========== Autodoc for {lib_func.function_name} ==========\n"
-        agent_log += format_agent_run_dump(run_result)
+        agent_log += format_agent_run_dump(run_result, model=args.library_model)
 
     if args.dump_agent_run:
         dump_path = save_file(
@@ -286,11 +286,12 @@ def run_library_learn_task(
         max_turns=args.max_turns,
     )
 
-    print_token_usage(run_result)
+    summary = summarize_token_usage(run_result, model=args.library_model)
+    print(summary)
 
     if args.dump_agent_run:
         dump_path = save_file(
-            format_agent_run_dump(run_result),
+            format_agent_run_dump(run_result, model=args.library_model),
             output_dir,
             f"learn_agent_{version}.log",
         )

--- a/agent/main.py
+++ b/agent/main.py
@@ -21,6 +21,7 @@ from .util import (
     SynthesisTask,
     extract_op_name,
     get_api_key,
+    get_op_output_dir,
     load_initial_library,
 )
 
@@ -129,7 +130,8 @@ def run_library_learning_loop(
     for op_name, agent in synth_agents.items():
         try:
             final_solution = agent.solution_set.build_final_solution()
-            final_solution_path = output_dir / f"final_solution_{op_name.lower()}.mlir"
+            op_output_dir = get_op_output_dir(output_dir, op_name)
+            final_solution_path = op_output_dir / f"final_solution_{op_name.lower()}.mlir"
             final_solution_path.write_text(final_solution)
             print(f"[{op_name.upper()}] Final solution: {final_solution_path}")
         except Exception as e:

--- a/agent/main.py
+++ b/agent/main.py
@@ -131,7 +131,7 @@ def run_library_learning_loop(
         try:
             final_solution = agent.solution_set.build_final_solution()
             op_output_dir = get_op_output_dir(output_dir, op_name)
-            final_solution_path = op_output_dir / f"final_solution_{op_name.lower()}.mlir"
+            final_solution_path = op_output_dir / f"final_solution_{op_name}.mlir"
             final_solution_path.write_text(final_solution)
             print(f"[{op_name.upper()}] Final solution: {final_solution_path}")
         except Exception as e:

--- a/agent/md/meet_instructions.md
+++ b/agent/md/meet_instructions.md
@@ -27,4 +27,4 @@ Workflow:
 Output contract:
 - Return ONLY MLIR func.func @kb_<op>. Do not wrap it in a module.
 - One operation per line; SSA form; no explanations.
-- Each line of MLIR must be exactly one operation from the allowed ops; do not write alias assignments like `%x = %y : !transfer.integer`
+- CRITICAL: Each MLIR line must be exactly one allowed operation. Never emit alias/copy assignments (forbidden: `%x = %y : !transfer.integer`).

--- a/agent/md/meet_instructions.md
+++ b/agent/md/meet_instructions.md
@@ -1,46 +1,29 @@
 You synthesize KnownBits transfer functions in MLIR for operation <OP> (file: <OP_FILE>).
 
-You are running in **meet mode**: your candidate will be combined with all previously accepted solutions via the meet operator. You do not need to cover every input — focus on inputs that existing solutions miss. A candidate that is sound globally and precise on a new subset of inputs will improve the collective solution set even if it is imprecise elsewhere.
-
-**IMPORTANT — how the solution set works across rounds:**
-- Each time you are invoked counts as one round. You are called repeatedly across multiple rounds to incrementally improve the solution set.
-- The solution set is updated after each round: if your candidate improved the set, it is permanently added before the next round begins.
-- Your previous round's solution is therefore already in the solution set. Submitting the same logic again will produce Updated == Previous (no improvement) because your candidate is already subsumed.
-- You must design a genuinely different candidate each round, targeting the inputs that are STILL imprecise after all existing solutions are combined.
-
 Use tools to fetch all materials; do not assume they are in this message:
 - get_task_bundle(): concrete op bundle:
 	- concrete_op: the concrete operator whose KnownBits transformer you synthesize
 	- op_constraint (optional): a predicate over concrete inputs; concretizations that violate it are out of scope
-	- note: you may leverage op_constraint and use it to sharpen the transformer; aim to be more precise than the unconstrained case
+	- note: use `op_constraint` to sharpen the transformer and improve precision beyond the unconstrained case. For example, if no concretization can satisfy `op_constraint`, return bottom (represented by `KnownZero = 1111` and `KnownOne = 1111`).
 - get_program_templates(): output templates
 - get_available_primitives(): allowed operators
 - list_examples()/search_examples()/get_example(): reference implementations
 - list_library_functions()/get_library_function(): retrieve available library functions
-- get_existing_solutions(): view the MLIR of all solutions already in the solution set
+- get_existing_solutions(): view the MLIR of all transfer functions already in the solution set
 - run_eval_improve(mlir): evaluate your candidate combined with existing solutions via meet; returns two lines — "Previous" (current solution set) and "Updated" (after adding your candidate)
+	- Make liberal use of run_eval_improve — eval early and eval often. Do not wait until you think your solution is complete; use it to check partial ideas and intermediate candidates as well.
 
-Make liberal use of run_eval_improve — eval early and eval often. Do not wait until you think your solution is complete; use it to check partial ideas and intermediate candidates as well.
-
+You aim to find a prefect (i.e. Sound % = 100 and (Exact % = 100 or Dist = 0)) transfer function.
 Workflow:
-1. **Call get_existing_solutions() first — this is mandatory.** Read the MLIR of every existing solution carefully. Understand what logic each one encodes, and what input patterns it covers precisely. Do not skip this step.
-2. Study the imprecise counterexamples shown (from an early run_eval_improve call). Identify patterns in the inputs that the current solution set handles imprecisely — e.g., "when %0 is all-unknown and %1 has known high bits, the result should propagate %1's high bits."
+1. Call get_existing_solutions() first. Read the MLIR of every existing solution carefully. Understand what logic each one encodes, and what input patterns it covers precisely. Do not skip this step.
+2. Run run_eval_improve early to inspect imprecise counterexamples. Identify input patterns the current solution set still handles imprecisely.
 3. Prefer general improvements that cover broad families of inputs; avoid candidates that only solve one narrow case.
 4. If the library is not empty, prefer reusing library functions — call list_library_functions() at the start and check for functions that match or closely approximate the operation before writing anything from scratch.
-5. Write your candidate, then immediately call run_eval_improve to test it. Use the feedback to iterate.
-
-**What to do when Updated == Previous (no improvement):**
-- This means your candidate is already subsumed by the existing solution set — it adds no new precision.
-- Do NOT return this candidate. You must try a different approach.
-- Go back to the counterexamples and pick a specific imprecise case. Ask: what is the minimum logic needed to exactly match `best` for that case? Write a candidate specialized for that pattern but still globaly sound and test it.
-- Keep iterating with different strategies until you find one that improves Exact % or lowers Dist.
-
-Rules:
-- You must call run_eval_improve with your MLIR before returning. If it returns a parse error, fix the MLIR and call again.
-- If the Updated line shows Sound % < 100, you must fix the soundness issue and call eval again before returning.
-- If the Updated line shows Sound % = 100 and you shrink the exactness gap (i.e., 1 - exact%) by at least 20%, you may return even if Exact % is still below 100.
-- If the Updated line shows Sound % = 100 and (Exact % = 100 or Dist = 0), you have already reached a perfect result and may return immediately.
-- **CRITICAL: Do not return a candidate that does not improve Exact % (or lower Dist) compared to the Previous line. Updated == Previous means failure — try a different candidate.**
+5. Write your candidate, then immediately call run_eval_improve to test it. Use the feedback of counterexamples to iterate.
+	- If Sound % < 100: fix soundness first, then evaluate again before returning.
+	- If Sound % = 100 and (Exact % < 100 and Dist > 0): keep improving precision. Diagnose the gap (for example, missing cases or weak bit propagation) and try a stronger design.
+	- If Sound % = 100 and (Exact % = 100 or Dist = 0): you have reached a perfect result; you may return immediately.
+	- If further changes would make the solution overcomplicated (for example, likely overfitting to a specific bitwidth), you may stop. **However, do not return a candidate unless it improves 	Exact % or lowers Dist versus the existing solution set.**
 
 Output contract:
 - Return ONLY MLIR func.func @kb_<op>. Do not wrap it in a module.

--- a/agent/md/meet_instructions.md
+++ b/agent/md/meet_instructions.md
@@ -15,11 +15,10 @@ Use tools to fetch all materials; do not assume they are in this message:
 
 You aim to find a prefect (i.e. Sound % = 100 and (Exact % = 100 or Dist = 0)) transfer function.
 Workflow:
-1. Call get_existing_solutions() first. Read the MLIR of every existing solution carefully. Understand what logic each one encodes, and what input patterns it covers precisely. Do not skip this step.
+1. Call get_existing_solutions() first. Read the MLIR of every existing solution carefully. Understand what logic each one encodes.
 2. Run run_eval_improve early to inspect imprecise counterexamples. Identify input patterns the current solution set still handles imprecisely.
-3. Prefer general improvements that cover broad families of inputs; avoid candidates that only solve one narrow case.
-4. If the library is not empty, prefer reusing library functions — call list_library_functions() at the start and check for functions that match or closely approximate the operation before writing anything from scratch.
-5. Write your candidate, then immediately call run_eval_improve to test it. Use the feedback of counterexamples to iterate.
+3. If the library is not empty, prefer reusing library functions — call list_library_functions() at the start and check for functions that match or closely approximate the operation before writing anything from scratch.
+4. Write your candidate. Prefer general improvements that cover broad families of inputs; avoid candidates that only solve one narrow case. Then immediately call run_eval_improve to test it. Use the feedback to iterate.
 	- If Sound % < 100: fix soundness first, then evaluate again before returning.
 	- If Sound % = 100 and (Exact % < 100 and Dist > 0): keep improving precision. Diagnose the gap (for example, missing cases or weak bit propagation) and try a stronger design.
 	- If Sound % = 100 and (Exact % = 100 or Dist = 0): you have reached a perfect result; you may return immediately.

--- a/agent/synth.py
+++ b/agent/synth.py
@@ -271,16 +271,12 @@ class SynthesisAgent:
             """
 
             print(f"[{task.op_name.upper()}] [TOOL] run_eval_improve:", flush=True)
-            try:
-                result = self.solution_set.eval_improve(
-                    transformer_mlir,
-                    self._eval_args,
-                )
-            except Exception as e:
-                msg = str(e).strip() or repr(e) or type(e).__name__
-                result = f"error: {' '.join(msg.splitlines())[:1500]}"
+            summary, eval_result = self.solution_set.eval_improve(
+                transformer_mlir,
+                self._eval_args,
+            )
             print(
-                f"[{task.op_name.upper()}] [TOOL] run_eval_improve result:\n{result}",
+                f"[{task.op_name.upper()}] [TOOL] run_eval_improve result:\n{summary}",
                 flush=True,
             )
 
@@ -294,10 +290,12 @@ class SynthesisAgent:
                 f"xfer_{round_tag}_{task.op_name}_{call_tag}.mlir",
             )
             _ = save_file(
-                result, op_output_dir, f"eval_{round_tag}_{task.op_name}_{call_tag}.txt"
+                summary, op_output_dir, f"eval_{round_tag}_{task.op_name}_{call_tag}.txt"
             )
+            if eval_result and eval_result.is_sound():
+                self._soln_iters.append(transformer_mlir)
 
-            return result
+            return summary
 
         return Agent(
             name="TransformerSynthesizer",
@@ -397,7 +395,7 @@ async def run_single_synthesis_task(
     print(f"{tag} Evaluating transformer...")
     eval_t0 = time.monotonic()
     if args.meet:
-        eval_summary = synth_agent.solution_set.eval_improve(
+        eval_summary, _ = synth_agent.solution_set.eval_improve(
             solution_text,
             synth_agent._eval_args,
             no_previous=True,

--- a/agent/synth.py
+++ b/agent/synth.py
@@ -19,8 +19,9 @@ from .util import (
     SynthesisTask,
     clean_llm_output,
     eval_transformer,
-    print_token_usage,
+    get_op_output_dir,
     save_file,
+    summarize_token_usage,
 )
 
 
@@ -259,6 +260,9 @@ class SynthesisAgent:
             Updated:  Sound/Exact/Dist after adding your candidate via meet
 
             Each line has the format: Sound %: ..., Exact %: ..., Dist: ...
+            - Sound %: fraction of inputs where the abstract output is sound
+            - Exact %: fraction where the result matches the optimal transfer (full precision)
+            - Dist: sound-distance metric for this eval
             An improvement shows higher Exact % or lower Dist on the Updated line.
 
             If the combined transformer is not fully sound or not fully precise, following lines may includeshort legend and up to a few concrete counterexamples per bitwidth (unsound vs imprecise labeled with bw=..., so you can see inputs, your abstract output, and the optimal abstract output.
@@ -338,6 +342,7 @@ async def run_single_synthesis_task(
     print(f"{tag} Synthesizing: round={round_num}, op={task.op_name}")
 
     output_dir = Path(args.output)
+    op_output_dir = get_op_output_dir(output_dir, task.op_name)
 
     run_result = None
     agent_input = None
@@ -354,17 +359,17 @@ async def run_single_synthesis_task(
     if not args.mock_synth:
         if args.dump_agent_run:
             dump_path = save_file(
-                format_agent_run_dump(run_result),
-                output_dir,
+                format_agent_run_dump(run_result, args.synth_model),
+                op_output_dir,
                 f"synth_agent_r{round_num}_{task.op_name.lower()}.log",
             )
             print(f"{tag} Agent run dump: {dump_path}")
 
-        print_token_usage(run_result)
+        print(f"{tag} Token usage: {summarize_token_usage(run_result, args.synth_model)}")
 
     transformer_file = save_file(
         clean_llm_output(llm_output),
-        output_dir,
+        op_output_dir,
         f"kb_r{round_num}_{task.op_name.lower()}.mlir",
     )
     print(f"{tag} Transformer: {transformer_file}")
@@ -389,7 +394,7 @@ async def run_single_synthesis_task(
     print(f"{tag} Eval result: {eval_summary}")
     save_file(
         f"synthesis_time: {synthesis_time:.2f}s\neval_time: {eval_time:.2f}s\n\n{eval_summary}",
-        output_dir,
+        op_output_dir,
         f"eval_r{round_num}_{task.op_name.lower()}.txt",
     )
 

--- a/agent/synth.py
+++ b/agent/synth.py
@@ -36,7 +36,7 @@ def build_agent_instructions(
 ) -> str:
     """Instantiate agent_instructions.md template with task-specific values."""
     instructions = template.replace("<OP>", op_name)
-    instructions = instructions.replace("<op>", op_name.lower())
+    instructions = instructions.replace("<op>", op_name)
     instructions = instructions.replace("<OP_FILE>", op_file)
     return instructions
 
@@ -57,6 +57,8 @@ class SynthesisAgent:
         self._library = current_lib
         self._history: list[Any] | None = None
         self._soln_iters: list[str] = []
+        self._current_round: int = 0
+        self._eval_call_idx: int = 0
         self._eval_args = eval_args_override or EvalArgs(
             op_path=Path(task.op_file),
             domain=AbstractDomain.KnownBits,
@@ -281,6 +283,20 @@ class SynthesisAgent:
                 f"[{task.op_name.upper()}] [TOOL] run_eval_improve result:\n{result}",
                 flush=True,
             )
+
+            round_tag = f"r{self._current_round}"
+            call_tag = f"{self._eval_call_idx:03d}"
+            self._eval_call_idx += 1
+            op_output_dir = get_op_output_dir(Path(self._args.output), task.op_name)
+            _ = save_file(
+                transformer_mlir,
+                op_output_dir,
+                f"xfer_{round_tag}_{task.op_name}_{call_tag}.mlir",
+            )
+            _ = save_file(
+                result, op_output_dir, f"eval_{round_tag}_{task.op_name}_{call_tag}.txt"
+            )
+
             return result
 
         return Agent(
@@ -311,6 +327,8 @@ class SynthesisAgent:
     async def run(self, round_num: int) -> tuple[str, object, Any, list[str]]:
         """Run one synthesis round. Returns (final_output, run_result, inp, evalled_transformers)."""
         self._soln_iters = []
+        self._current_round = round_num
+        self._eval_call_idx = 0
         if self._history is None:
             user_content = f"{_make_initial_prompt(self._task)}\n"
         else:
@@ -361,7 +379,7 @@ async def run_single_synthesis_task(
             dump_path = save_file(
                 format_agent_run_dump(run_result, args.synth_model),
                 op_output_dir,
-                f"synth_agent_r{round_num}_{task.op_name.lower()}.log",
+                f"synth_agent_r{round_num}_{task.op_name}.log",
             )
             print(f"{tag} Agent run dump: {dump_path}")
 
@@ -370,7 +388,7 @@ async def run_single_synthesis_task(
     transformer_file = save_file(
         clean_llm_output(llm_output),
         op_output_dir,
-        f"kb_r{round_num}_{task.op_name.lower()}.mlir",
+        f"xfer_r{round_num}_{task.op_name}.mlir",
     )
     print(f"{tag} Transformer: {transformer_file}")
 
@@ -395,7 +413,7 @@ async def run_single_synthesis_task(
     save_file(
         f"synthesis_time: {synthesis_time:.2f}s\neval_time: {eval_time:.2f}s\n\n{eval_summary}",
         op_output_dir,
-        f"eval_r{round_num}_{task.op_name.lower()}.txt",
+        f"eval_r{round_num}_{task.op_name}.txt",
     )
 
     return SynthesisResult(

--- a/agent/synth.py
+++ b/agent/synth.py
@@ -55,7 +55,6 @@ class SynthesisAgent:
         self._task = task
         self._args = args
         self._library = current_lib
-        self._history: list[Any] | None = None
         self._soln_iters: list[str] = []
         self._current_round: int = 0
         self._eval_call_idx: int = 0
@@ -327,7 +326,7 @@ class SynthesisAgent:
         self._soln_iters = []
         self._current_round = round_num
         self._eval_call_idx = 0
-        if self._history is None:
+        if round_num <= 0:
             user_content = f"{_make_initial_prompt(self._task)}\n"
         else:
             user_content = (
@@ -338,11 +337,8 @@ class SynthesisAgent:
                 "applicable."
             )
         user_content += f"\nYou have a maximum of {self._args.max_turns} iterations to complete this task, If you are going to exceed the limit, return the current MLIR you have generated."
-        inp: list[Any] = (self._history or []) + [
-            {"role": "user", "content": user_content}
-        ]
+        inp: list[Any] = [{"role": "user", "content": user_content}]
         result = await Runner.run(self._agent, inp, max_turns=self._args.max_turns)
-        self._history = result.to_input_list()
         return result.final_output, result, inp, list(self._soln_iters)
 
 

--- a/agent/util.py
+++ b/agent/util.py
@@ -15,6 +15,16 @@ from synth_xfer._util.lower import LowerToLLVM
 from synth_xfer._util.parse_mlir import get_helper_funcs, parse_mlir_mod, top_as_xfer
 from synth_xfer._util.random import Random, Sampler
 
+TOKEN_PRICING_PER_1M = {
+    "gpt-5.3-codex": (1.75, 0.175, 14.00),
+    "gpt-5.2-codex": (1.75, 0.175, 14.00),
+    "gpt-5.1-codex-max": (1.25, 0.125, 10.00),
+    "gpt-5.1-codex": (1.25, 0.125, 10.00),
+    "gpt-5-codex": (1.25, 0.125, 10.00),
+    "gpt-5.1-codex-mini": (0.25, 0.025, 2.00),
+    "codex-mini-latest": (1.50, 0.375, 6.00),
+}
+
 
 @dataclass
 class EvalArgs:
@@ -79,6 +89,27 @@ class LibraryState(BaseModel):
             "  " + line if line.strip() else "" for line in body.splitlines()
         )
         return f"builtin.module {{\n{indented}\n}}"
+
+
+@dataclass
+class TokenUsageSummary:
+    input_tokens: int
+    cached_input_tokens: int
+    output_tokens: int
+    estimated_cost_usd: float | None
+
+    def __str__(self) -> str:
+        cost = (
+            f"${self.estimated_cost_usd:.6f}"
+            if self.estimated_cost_usd is not None
+            else "N/A"
+        )
+        return (
+            f"Token usage: input={self.input_tokens:,}, "
+            f"cached_input={self.cached_input_tokens:,}, "
+            f"output={self.output_tokens:,}, "
+            f"estimated_cost={cost}"
+        )
 
 
 def get_api_key() -> str:
@@ -174,23 +205,31 @@ def make_output_dir(output_dir: Path):
     (output_dir / "log").mkdir(exist_ok=True)
 
 
-def print_token_usage(run_result) -> None:
-    """Print aggregated token usage from agent run."""
-    inp = out = reason = 0
+def summarize_token_usage(run_result, model: str | None = None) -> TokenUsageSummary:
+    """Aggregate input/cached-input/output tokens and estimate model cost."""
+    inp = cached_inp = out = 0
     for resp in getattr(run_result, "raw_responses", []):
         u = getattr(resp, "usage", None)
         if u is None:
             continue
         inp += getattr(u, "input_tokens", 0) or 0
         out += getattr(u, "output_tokens", 0) or 0
-        od = getattr(u, "output_tokens_details", None)
-        if od is not None:
-            reason += getattr(od, "reasoning_tokens", 0) or 0
-    total = inp + out + reason
-    token_str = f"{inp:,} input, {out:,} output" + (
-        f", {reason:,} reasoning" if reason else ""
+        idetails = getattr(u, "input_tokens_details", None)
+        if idetails is not None:
+            cached_inp += getattr(idetails, "cached_tokens", 0) or 0
+
+    pricing = TOKEN_PRICING_PER_1M.get(model.lower()) if model else None
+    if pricing is None:
+        return TokenUsageSummary(inp, cached_inp, out, None)
+
+    input_rate, cached_input_rate, output_rate = pricing
+    non_cached_input = max(inp - cached_inp, 0)
+    estimated_cost_usd = (
+        (non_cached_input / 1_000_000.0) * input_rate
+        + (cached_inp / 1_000_000.0) * cached_input_rate
+        + (out / 1_000_000.0) * output_rate
     )
-    print(f"Tokens: {token_str} ({total:,} total)")
+    return TokenUsageSummary(inp, cached_inp, out, estimated_cost_usd)
 
 
 def save_file(content: str, dir: Path, file_name: str) -> Path:
@@ -199,6 +238,13 @@ def save_file(content: str, dir: Path, file_name: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return path
+
+
+def get_op_output_dir(base_output: Path, op_name: str) -> Path:
+    """Return and create the per-operator output directory."""
+    op_dir = Path(base_output) / op_name
+    op_dir.mkdir(parents=True, exist_ok=True)
+    return op_dir
 
 
 def dump_library(lib: LibraryState, out_dir: Path) -> Path:


### PR DESCRIPTION
1. Change the instruction of the meet mode, aiming for a perfect transformer.
2. Dump the transformer each time the agent calls the eval tool.
3. No longer pass the history conversation as the prompt into the next round
4. Use `soln_iters[-1]` rather than the llm response as the solution