### PR TITLE
Update the interface of `pattern eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,14 +330,16 @@ pattern generate-input             \
 | `--composite-xfer <Path>` | Composite MLIR transformer to compare against.                |
 | `--xfer-name <str>`       | Optional function name inside the composite MLIR file.        |
 | `-i, --input <Path>`      | Enum TSV input data, typically from `pattern generate-input`. |
-| `--exact-bw <int>`        | Bitwidth used for exact pattern eval.                         |
-| `--norm-bw <int>`         | Bitwidth used for norm pattern eval.                          |
+| `--bw <int>`              | Bitwidth used for the eval (default: 8).                       |
+
+Prints a table comparing the LLVM seq pattern against the composite transformer at the chosen bitwidth.
 
 Example:
 ```bash
 pattern eval                             \
   --composite-xfer composite_008.mlir    \
   -i pattern_008_enum_data.tsv           \
+  --bw 8
 ```
 
 ## Important CLI Options for `simplifier`

--- a/cpp/bindings/bindings_common.hpp
+++ b/cpp/bindings/bindings_common.hpp
@@ -69,10 +69,6 @@ using EnumHighThunk = py::object (*)(std::uintptr_t,
 using EvalThunk = Results (*)(py::handle, const std::vector<std::uintptr_t> &,
                               const std::vector<std::uintptr_t> &, unsigned int,
                               unsigned int);
-using EvalPatternThunk = std::pair<double, double> (*)(py::handle,
-                                                       const std::vector<double> &,
-                                                       const std::string &,
-                                                       std::uintptr_t);
 using RunThunk = py::object (*)(py::handle, std::uintptr_t);
 using LenThunk = std::size_t (*)(py::handle);
 using GetItemThunk = py::object (*)(py::handle, std::size_t);
@@ -81,8 +77,14 @@ using IterThunk = py::object (*)(py::handle);
 void bind_enum_funcs(py::module_ &m, const std::string &fn_name,
                      EnumLowThunk low, EnumMidThunk mid, EnumHighThunk high);
 void bind_eval_func(py::module_ &m, const std::string &fn_name, EvalThunk eval);
+// Templated on the thunk so exact (4-tuple) and norm (pair) returns can share
+// one binder; pybind11 deduces the Python return type from the callable.
+template <typename Thunk>
 void bind_eval_pattern_func(py::module_ &m, const std::string &fn_name,
-                            EvalPatternThunk eval);
+                            Thunk eval) {
+  m.def(fn_name.c_str(), eval, py::arg("rows"), py::arg("weights"),
+        py::arg("pattern"), py::arg("composite"));
+}
 void bind_run_func(py::module_ &m, const std::string &fn_name, RunThunk run);
 template <typename PyClass>
 void bind_sequence_protocol(PyClass &cls, LenThunk len, GetItemThunk getitem,
@@ -301,8 +303,8 @@ void register_eval_pattern_domain(py::module_ &m) {
   bind_eval_pattern_func(
       m, exact_fn_name,
       +[](py::handle to_eval, const std::vector<double> &weights,
-          const std::string &pattern,
-          std::uintptr_t composite_addr) -> std::pair<double, double> {
+          const std::string &pattern, std::uintptr_t composite_addr)
+          -> std::tuple<double, double, double, double, double, double> {
         const EvalVec &v = py::cast<const EvalVec &>(to_eval);
         auto exact_rows = make_exact_pattern_rows<EvalPatternT>(v, weights);
         py::gil_scoped_release release;

--- a/cpp/bindings/bindings_helpers.cpp
+++ b/cpp/bindings/bindings_helpers.cpp
@@ -95,11 +95,7 @@ void bind_eval_func(py::module_ &m, const std::string &fn_name,
         py::arg("bases"), py::arg("unsound_ex") = 0, py::arg("imprecise_ex") = 0);
 }
 
-void bind_eval_pattern_func(py::module_ &m, const std::string &fn_name,
-                            EvalPatternThunk eval) {
-  m.def(fn_name.c_str(), eval, py::arg("rows"), py::arg("weights"),
-        py::arg("pattern"), py::arg("composite"));
-}
+// bind_eval_pattern_func is a template defined in bindings_common.hpp.
 
 void bind_run_func(py::module_ &m, const std::string &fn_name, RunThunk run) {
   m.def(fn_name.c_str(), run, py::arg("to_run"), py::arg("xfer_addr"));

--- a/cpp/core/eval.hpp
+++ b/cpp/core/eval.hpp
@@ -87,11 +87,22 @@ public:
       : composite_xfer_(std::move(composite)),
         pattern_(PatternTy::parse(pattern)) {}
 
-  [[nodiscard]] std::pair<double, double>
+  // Returns (llvm_seq_sound%, composite_sound%, llvm_seq_exact%,
+  // composite_exact%, llvm_seq_dist, composite_dist). "Sound" means the result
+  // over-approximates the optimal (isSuperset of best); "exact" means it equals
+  // the optimal; "dist" is the weighted-mean imprecision dist(result, best) on
+  // a [0,1] norm scale (mirrors the full Eval path; dist() asserts on
+  // incomparable elements, which sound xfers never produce).
+  [[nodiscard]]
+  std::tuple<double, double, double, double, double, double>
   eval_pattern_exact(const std::vector<ExactRow> &rows) const {
     long double total_weight = 0.0L;
+    long double llvm_seq_sound_weight = 0.0L;
+    long double composite_sound_weight = 0.0L;
     long double llvm_seq_correct_weight = 0.0L;
     long double composite_correct_weight = 0.0L;
+    long double llvm_seq_dist_weight = 0.0L;
+    long double composite_dist_weight = 0.0L;
 
     for (const auto &row : rows) {
       const long double inv_weight =
@@ -101,19 +112,34 @@ public:
       const auto composite_result = run_fn_ptr(composite_xfer_, row.args);
       const auto llvm_seq_result = run_llvm_pattern(pattern_, row.args);
 
+      if (isSuperset(llvm_seq_result, row.best))
+        llvm_seq_sound_weight += inv_weight;
+      if (isSuperset(composite_result, row.best))
+        composite_sound_weight += inv_weight;
       if (llvm_seq_result == row.best)
         llvm_seq_correct_weight += inv_weight;
       if (composite_result == row.best)
         composite_correct_weight += inv_weight;
+
+      llvm_seq_dist_weight +=
+          static_cast<long double>(dist(llvm_seq_result, row.best)) *
+          inv_weight;
+      composite_dist_weight +=
+          static_cast<long double>(dist(composite_result, row.best)) *
+          inv_weight;
     }
 
     if (total_weight == 0.0L) {
-      return {0.0, 0.0};
+      return {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     }
 
     return {
+        static_cast<double>(100.0L * llvm_seq_sound_weight / total_weight),
+        static_cast<double>(100.0L * composite_sound_weight / total_weight),
         static_cast<double>(100.0L * llvm_seq_correct_weight / total_weight),
         static_cast<double>(100.0L * composite_correct_weight / total_weight),
+        static_cast<double>(llvm_seq_dist_weight / total_weight),
+        static_cast<double>(composite_dist_weight / total_weight),
     };
   }
 

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -102,13 +102,19 @@ def _get_eval_fn(
 
 def _get_eval_pattern_exact_fn(
     to_eval: ToEval,
-) -> Callable[[ToEval, list[float], str, int], tuple[float, float]]:
+) -> Callable[
+    [ToEval, list[float], str, int],
+    tuple[float, float, float, float, float, float],
+]:
     def _eval_engine_name(to_eval: ToEval) -> str:
         suffix = to_eval.__class__.__name__.lower()[6:]
         return f"eval_pattern_exact_{suffix}"
 
     return cast(
-        Callable[[ToEval, list[float], str, int], tuple[float, float]],
+        Callable[
+            [ToEval, list[float], str, int],
+            tuple[float, float, float, float, float, float],
+        ],
         _get_ee_fn_dyn(_eval_engine_name(to_eval)),
     )
 

--- a/synth_xfer/_util/eval.py
+++ b/synth_xfer/_util/eval.py
@@ -304,7 +304,9 @@ def parse_to_eval_inputs(
 
 def eval_pattern_exact(
     to_eval: ToEval, weights: list[float], pattern: str, composite: FnPtr
-) -> tuple[float, float]:
+) -> tuple[float, float, float, float, float, float]:
+    # (llvm_seq_sound%, composite_sound%, llvm_seq_exact%, composite_exact%,
+    #  llvm_seq_dist, composite_dist)
     return _get_eval_pattern_exact_fn(to_eval)(to_eval, weights, pattern, composite.addr)
 
 

--- a/synth_xfer/_util/pattern.py
+++ b/synth_xfer/_util/pattern.py
@@ -19,8 +19,8 @@ from synth_xfer._util.parse_mlir import (
 )
 from synth_xfer._util.tsv import EnumData, resolve_dataset_op_path
 from synth_xfer._util.xfer_data import (
-    enumdata_to_eval_inputs,
-    enumdata_to_run_inputs,
+    enumdata_to_eval_input,
+    enumdata_to_run_input,
     resolve_xfer_name,
 )
 
@@ -376,49 +376,59 @@ def eval_pattern(
     composite_xfer: Path,
     xfer_name: str | None,
     data: EnumData,
-    exact_bw: int,
-    norm_bw: int,
-) -> tuple[float, float, float, float]:
+    bw: int,
+) -> tuple[float, float, float, float, float, float, float, float]:
     comp_mod = parse_mlir_mod(composite_xfer)
     comp_xfer_name = resolve_xfer_name(get_fns(comp_mod), xfer_name)
 
-    if exact_bw not in [x[0] for x in data.metadata.mbw + data.metadata.hbw]:
-        raise ValueError(f"Exact BW {exact_bw} not in Enum TSV")
-    if norm_bw not in [x[0] for x in data.metadata.mbw + data.metadata.hbw]:
-        raise ValueError(f"Norm BW {norm_bw} not in Enum TSV")
+    if bw not in [x[0] for x in data.metadata.mbw + data.metadata.hbw]:
+        raise ValueError(f"BW {bw} not in Enum TSV")
 
-    exact_to_eval = enumdata_to_eval_inputs(data)[exact_bw]
-    norm_to_eval = enumdata_to_run_inputs(data)[norm_bw]
+    exact_to_eval = enumdata_to_eval_input(data, bw)
+    norm_to_eval = enumdata_to_run_input(data, bw)
 
-    exact_weights = (
-        data.enumdata[data.enumdata["bw"] == exact_bw]["weight"].astype(float).tolist()
-    )
-    norm_weights = (
-        data.enumdata[data.enumdata["bw"] == norm_bw]["weight"].astype(float).tolist()
-    )
+    rows = data.enumdata[data.enumdata["bw"] == bw]
+    if "weight" not in data.enumdata.columns:
+        # Uniform weighting: a constant weight makes the eval score a plain
+        # unweighted average (the score normalizes by the weight sum).
+        weights = [1.0] * len(rows)
+    else:
+        weights = rows["weight"].astype(float).tolist()
 
     helpers = get_helper_funcs(
         resolve_dataset_op_path(data.metadata.op), data.metadata.domain
     )
-    lowerer = LowerToLLVM(sorted({exact_bw, norm_bw}))
+    lowerer = LowerToLLVM([bw])
     lowerer.add_fn(helpers.meet_func)
     lowerer.add_fn(helpers.get_top_func)
     lowerer.add_mod(comp_mod, [comp_xfer_name])
 
     with Jit() as jit:
         jit.add_mod(lowerer)
-        seq_exact, comp_exact = eval_pattern_exact(
-            exact_to_eval,
-            exact_weights,
-            pattern_str,
-            jit.get_fn_ptr(f"{comp_xfer_name}_{exact_bw}_shim"),
+        shim_ptr = jit.get_fn_ptr(f"{comp_xfer_name}_{bw}_shim")
+        seq_sound, comp_sound, seq_exact, comp_exact, seq_dist, comp_dist = (
+            eval_pattern_exact(
+                exact_to_eval,
+                weights,
+                pattern_str,
+                shim_ptr,
+            )
         )
 
         seq_norm, comp_norm = eval_pattern_norm(
             norm_to_eval,
-            norm_weights,
+            weights,
             pattern_str,
-            jit.get_fn_ptr(f"{comp_xfer_name}_{norm_bw}_shim"),
+            shim_ptr,
         )
 
-    return seq_exact, comp_exact, seq_norm, comp_norm
+    return (
+        seq_sound,
+        comp_sound,
+        seq_exact,
+        comp_exact,
+        seq_dist,
+        comp_dist,
+        seq_norm,
+        comp_norm,
+    )

--- a/synth_xfer/_util/xfer_data.py
+++ b/synth_xfer/_util/xfer_data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, cast
 
 import pandas as pd
 from xdsl.dialects.builtin import ModuleOp, StringAttr, SymbolRefAttr
@@ -267,10 +267,10 @@ def enumdata_to_eval_inputs(data: EnumData) -> dict[int, ToEval]:
 def enumdata_to_eval_input(data: EnumData, bw: int) -> ToEval:
     # Parse only the requested bw so unsupported bws in the TSV are never
     # looked up in the eval engine (the plural variant parses every bw group).
-    rows = data.enumdata[data.enumdata["bw"] == bw]
+    rows = cast(pd.DataFrame, data.enumdata[data.enumdata["bw"] == bw])
     return parse_eval_df(rows, data.metadata.domain, data.metadata.arity, bw)
 
 
 def enumdata_to_run_input(data: EnumData, bw: int) -> ArgsVec:
-    rows = data.enumdata[data.enumdata["bw"] == bw]
+    rows = cast(pd.DataFrame, data.enumdata[data.enumdata["bw"] == bw])
     return parse_enum_df(rows, data.metadata.domain, data.metadata.arity, bw)

--- a/synth_xfer/_util/xfer_data.py
+++ b/synth_xfer/_util/xfer_data.py
@@ -262,3 +262,15 @@ def enumdata_to_run_inputs(data: EnumData) -> RunInputMap:
 
 def enumdata_to_eval_inputs(data: EnumData) -> dict[int, ToEval]:
     return _enumdata_to_inputs(data, parse_eval_df)  # type: ignore
+
+
+def enumdata_to_eval_input(data: EnumData, bw: int) -> ToEval:
+    # Parse only the requested bw so unsupported bws in the TSV are never
+    # looked up in the eval engine (the plural variant parses every bw group).
+    rows = data.enumdata[data.enumdata["bw"] == bw]
+    return parse_eval_df(rows, data.metadata.domain, data.metadata.arity, bw)
+
+
+def enumdata_to_run_input(data: EnumData, bw: int) -> ArgsVec:
+    rows = data.enumdata[data.enumdata["bw"] == bw]
+    return parse_enum_df(rows, data.metadata.domain, data.metadata.arity, bw)

--- a/synth_xfer/cli/pattern.py
+++ b/synth_xfer/cli/pattern.py
@@ -128,8 +128,7 @@ def _eval_args(p: ArgumentParser):
         required=True,
         help="path to enum TSV (use `pattern generate-input` to make this)",
     )
-    p.add_argument("--exact-bw", type=int, default=8, help="BW to use for exact eval")
-    p.add_argument("--norm-bw", type=int, default=64, help="BW to use for norm eval")
+    p.add_argument("--bw", type=int, default=8, help="BW to use for eval")
 
 
 def main() -> None:
@@ -226,19 +225,52 @@ def main() -> None:
 
         pattern_path = Path(data.metadata.op)
         dag = load_pattern(pattern_path)
-        seq_exact, comp_exact, seq_norm, comp_norm = eval_pattern(
+        (
+            seq_sound,
+            comp_sound,
+            seq_exact,
+            comp_exact,
+            seq_dist,
+            comp_dist,
+            seq_norm,
+            comp_norm,
+        ) = eval_pattern(
             dag.expression,
             args.composite_xfer,
             args.xfer_name,
             data,
-            args.exact_bw,
-            args.norm_bw,
+            args.bw,
         )
 
-        print("Type       | Exact % | Norm Score")
-        print("-----------|---------|-------------")
-        print(f"LLVM Seq   | {seq_exact:6.2f}% | {seq_norm:.5f}")
-        print(f"Composite  | {comp_exact:6.2f}% | {comp_norm:.5f}")
+        # Dist is only meaningful when `best` is the true optimal, i.e. for
+        # exhaustively-enumerated (mbw) bitwidths. hbw samples concretizations
+        # and computes no ideal, so omit the column there.
+        hbw_bws = {b for b, _, _ in data.metadata.hbw}
+        if args.bw not in hbw_bws:
+
+            def _dist_cell(sound: float, dist: float) -> str:
+                # Dist is a clean imprecision measure only for a fully sound
+                # result; for an unsound one it conflates imprecision with
+                # unsoundness, so don't report a number.
+                if sound >= 100.0 - 1e-9:
+                    return f"{dist:.5f}"
+                return "unsound"
+
+            print(f"Type       | Sound % | Exact % |  Norm   |   Dist  (bw={args.bw})")
+            print("-----------|---------|---------|---------|---------")
+            print(
+                f"LLVM Seq   | {seq_sound:6.2f}% | {seq_exact:6.2f}% | {seq_norm:7.5f} | {_dist_cell(seq_sound, seq_dist):>7}"
+            )
+            print(
+                f"Composite  | {comp_sound:6.2f}% | {comp_exact:6.2f}% | {comp_norm:7.5f} | {_dist_cell(comp_sound, comp_dist):>7}"
+            )
+        else:
+            print(f"Type       | Sound % | Exact % |  Norm    (bw={args.bw})")
+            print("-----------|---------|---------|---------")
+            print(f"LLVM Seq   | {seq_sound:6.2f}% | {seq_exact:6.2f}% | {seq_norm:7.5f}")
+            print(
+                f"Composite  | {comp_sound:6.2f}% | {comp_exact:6.2f}% | {comp_norm:7.5f}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. A single `--bw` option instead of specifying `--exact-bw` and `norm-bw` separately
2. Print `Sound %` and `Dist` as well
3. Treat it as a uniform distribution when the tsv lacks a `weight` column