### PR TITLE
A few small patches

### DIFF
--- a/synth_xfer/llvm_eval/README.md
+++ b/synth_xfer/llvm_eval/README.md
@@ -53,13 +53,10 @@ OPT=$LLVM_DIR/build/bin/opt
 ```
 
 ```bash
-# 1. stub transformers -> dispatcher
-python3 -m synth_xfer.llvm_eval.build_xfer \
-    --pat-list llvm_results/test_patterns.tsv \
-    --output-dir outputs/test_pat/xfer \
-    -d KnownBits
-python3 -m synth_xfer.llvm_eval.generate_matcher \
-    --input-dir outputs/test_pat/xfer \
+# 1. stub transformers -> dispatcher (generated and wired into LLVM in one step)
+python3 -m synth_xfer.llvm_eval.generate_xfers stubs \
+    --patterns llvm_results/test_patterns.tsv \
+    -d KnownBits \
     --llvm-dir $LLVM_DIR
 
 # 2. rebuild opt
@@ -81,14 +78,10 @@ python3 -m synth_xfer.llvm_eval.prune_tables \
     --tsv-dir outputs/test_pat/tables \
     --out-dir outputs/test_pat/pruned
 
-# 6. table-backed transformers -> dispatcher (--include-helper needed for blobs) -> rebuild
-python3 -m synth_xfer.llvm_eval.build_xfer \
+# 6. table-backed transformers -> dispatcher (generated and wired in one step) -> rebuild
+python3 -m synth_xfer.llvm_eval.generate_xfers tables \
     --table-dir outputs/test_pat/pruned \
-    --output-dir outputs/test_pat/xfer
-python3 -m synth_xfer.llvm_eval.generate_matcher \
-    --input-dir outputs/test_pat/xfer \
-    --llvm-dir $LLVM_DIR \
-    --include-helper
+    --llvm-dir $LLVM_DIR
 ninja -C $LLVM_DIR/build opt
 
 # 7. benchmark -> optimization stats

--- a/synth_xfer/llvm_eval/generate_xfers.py
+++ b/synth_xfer/llvm_eval/generate_xfers.py
@@ -786,6 +786,9 @@ class DispatcherEmitter:
         out.append(f"  {arg_decl}\n")
         out.append(_emit_guard(matcher))
         out.append("  unsigned ResBW = I->getType()->getScalarSizeInBits();\n")
+        # Non-integer results (e.g. pointers) report bw 0; skip them so we never
+        # build a zero-width KnownBits.
+        out.append("  if (ResBW == 0)\n    return std::nullopt;\n")
         if any(node.op in WIDTH_CHANGING_OPS for node in spec.dag.nodes):
             out.append(_emit_bw_guard(spec.dag.num_args))
         out.append(f"  ++Num{_symbol_id(self.domain, spec.id)}Matches;\n")

--- a/synth_xfer/llvm_eval/phase1_build_tables.sh
+++ b/synth_xfer/llvm_eval/phase1_build_tables.sh
@@ -2,35 +2,36 @@
 # Pipeline steps 1-5: build stub transformers, harvest a per-pattern histogram
 # from the benchmark, fill in SMT-optimal (max-precise) outputs, and prune.
 #
-# Deliverable: the pruned lookup tables in TABLE_DIR (input to phase2_eval.sh).
-# All other intermediates (transformer .inc, histograms, ideal tables) go to a
-# temp dir that is removed on exit.
+# Deliverable: the pruned lookup tables in WORK_DIR/pruned (input to
+# phase2_eval.sh). All intermediates (histograms, ideal tables) persist under
+# WORK_DIR too, so an interrupted run is not wiped.
 #
 # Run from the synth-xfer repo root, inside the venv. LLVM_DIR, BENCH_DIR and
 # PAT_LIST are required; the rest have defaults. e.g.
 #   LLVM_DIR=~/repos/llvm-project BENCH_DIR=~/repos/llvm-opt-benchmark \
 #       PAT_LIST=tests/data/pattern/top_10_pattern.tsv \
-#       TABLE_DIR=outputs/run1/tables ./phase1_build_tables.sh
+#       WORK_DIR=outputs/run1 ./phase1_build_tables.sh
 #
 #   LLVM_DIR    LLVM checkout with build/bin/opt   (required)
 #   BENCH_DIR   llvm-opt-benchmark checkout        (required)
 #   PAT_LIST    TSV with a `pattern` column        (required)
-#   TABLE_DIR   where the pruned tables go         (default outputs/pruned)
+#   WORK_DIR    holds all artifacts (hist/,        (default outputs/run)
+#               tables/, pruned/); pass
+#               WORK_DIR/pruned as TABLE_DIR to phase2
 #   FILTER      benchmark subdir filter, "" = all  (default "" = whole suite)
 set -euo pipefail
 
 : "${LLVM_DIR:?must be set to the llvm-project checkout (with build/bin/opt)}"
 : "${BENCH_DIR:?must be set to the llvm-opt-benchmark checkout}"
 : "${PAT_LIST:?must be set to a TSV with a \`pattern\` column}"
-TABLE_DIR="${TABLE_DIR:-outputs/pruned}"
+WORK_DIR="${WORK_DIR:-outputs/run}"
 FILTER="${FILTER:-}"
 
 OPT="$LLVM_DIR/build/bin/opt"
 filter_arg=()
 [[ -n "$FILTER" ]] && filter_arg=(--filter "$FILTER")
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$WORK_DIR"
 
 echo ">>> [1/5] stub transformers -> dispatcher"
 python3 -m synth_xfer.llvm_eval.generate_xfers stubs \
@@ -42,14 +43,14 @@ ninja -C "$LLVM_DIR/build" opt
 echo ">>> [3/5] benchmark -> histogram"
 python3 -m synth_xfer.llvm_eval.run_opt_benchmark \
     --bench-path "$BENCH_DIR" --opt-path "$OPT" \
-    --pattern-hist "$TMP/hist" "${filter_arg[@]}"
+    --pattern-hist "$WORK_DIR/hist" "${filter_arg[@]}"
 
 echo ">>> [4/5] max-precise (ideal outputs)"
 python3 -m synth_xfer.llvm_eval.run_max_precise \
-    "$TMP/hist" --output-dir "$TMP/tables"
+    "$WORK_DIR/hist" --output-dir "$WORK_DIR/tables"
 
 echo ">>> [5/5] prune tables"
 python3 -m synth_xfer.llvm_eval.prune_tables \
-    --tsv-dir "$TMP/tables" --out-dir "$TABLE_DIR"
+    --tsv-dir "$WORK_DIR/tables" --out-dir "$WORK_DIR/pruned"
 
-echo ">>> done. pruned tables in $TABLE_DIR (pass as TABLE_DIR to phase2_eval.sh)"
+echo ">>> done. pruned tables in $WORK_DIR/pruned (pass as TABLE_DIR to phase2_eval.sh)"

--- a/synth_xfer/llvm_eval/prune_tables.py
+++ b/synth_xfer/llvm_eval/prune_tables.py
@@ -347,7 +347,7 @@ def main() -> None:
     ap.add_argument(
         "--drop-locally-complete",
         action=BooleanOptionalAction,
-        default=False,
+        default=True,
         help="Drop rows whose ideal output equals sequential_ideal",
     )
     ap.add_argument(

--- a/synth_xfer/llvm_eval/prune_tables.py
+++ b/synth_xfer/llvm_eval/prune_tables.py
@@ -6,6 +6,8 @@ import sys
 from typing import Any, Callable, Hashable, cast
 
 from synth_xfer._util.domain import AbstractDomain, get_bvs_from_abst, is_top
+from synth_xfer._util.max_precise import _concrete_width
+from synth_xfer._util.parse_mlir import HelperFuncs
 from synth_xfer._util.tsv import EnumData
 
 Row = tuple[tuple[str, ...], str]
@@ -72,17 +74,26 @@ class FileStats:
         )
 
 
-def prune_group(rows: list[Row], domain: AbstractDomain, bw: int) -> list[int]:
+def prune_group(
+    rows: list[Row],
+    domain: AbstractDomain,
+    arg_widths: list[int],
+    result_width: int,
+) -> list[int]:
     """Minimal-cover pruning for rows of one bitwidth.
     Row B is redundant if another row A matches every query B matches, and A's
     ideal is at least as precise as B's ideal under the domain's meet semantics.
     The returned list maps each input row to the row that should receive its
     count; kept rows map to themselves.
+
+    ``arg_widths`` / ``result_width`` give each operand and the ideal its own
+    bitwidth: an operand like a Select condition is ``i1`` regardless of the
+    group's data width, so it cannot be parsed at a single ``bw``.
     """
     if domain == AbstractDomain.KnownBits:
-        return _prune_knownbits_group(rows, domain, bw)
+        return _prune_knownbits_group(rows, domain, arg_widths, result_width)
     if domain in (AbstractDomain.UConstRange, AbstractDomain.SConstRange):
-        return _prune_const_range_group(rows, domain, bw)
+        return _prune_const_range_group(rows, domain, arg_widths, result_width)
     raise NotImplementedError(f"{domain} not supported yet")
 
 
@@ -120,18 +131,23 @@ def row_int(row: Any, col: str) -> int:
     return int(cast(int, row[col]))
 
 
-def _prune_knownbits_group(rows: list[Row], domain: AbstractDomain, bw: int) -> list[int]:
+def _prune_knownbits_group(
+    rows: list[Row],
+    domain: AbstractDomain,
+    arg_widths: list[int],
+    result_width: int,
+) -> list[int]:
     # Per-row masks: combined arg (zero/one) masks, ideal (zero/one) masks, and
     # the count of known arg bits (a dominator can only have <= as many).
     feats: list[KBFeature] = []
     for args, ideal in rows:
         aZ = aO = shift = 0
-        for s in args:
-            z, o = cast(tuple[int, int], get_bvs_from_abst(s, domain, bw))
+        for s, w in zip(args, arg_widths):
+            z, o = cast(tuple[int, int], get_bvs_from_abst(s, domain, w))
             aZ |= z << shift
             aO |= o << shift
-            shift += len(s)
-        output = get_bvs_from_abst(ideal, domain, bw)
+            shift += w
+        output = get_bvs_from_abst(ideal, domain, result_width)
         feats.append((aZ, aO, output, bin(aZ | aO).count("1")))
 
     def dominates(a: KBFeature, b: KBFeature) -> bool:
@@ -151,7 +167,10 @@ def _prune_knownbits_group(rows: list[Row], domain: AbstractDomain, bw: int) -> 
 
 
 def _prune_const_range_group(
-    rows: list[Row], domain: AbstractDomain, bw: int
+    rows: list[Row],
+    domain: AbstractDomain,
+    arg_widths: list[int],
+    result_width: int,
 ) -> list[int]:
     def contains(outer: AbsValue, inner: AbsValue) -> bool:
         if inner is None:
@@ -163,9 +182,10 @@ def _prune_const_range_group(
     feats: list[CRFeature] = []
     for args, ideal in rows:
         arg_ranges = tuple(
-            cast(Interval, get_bvs_from_abst(arg, domain, bw)) for arg in args
+            cast(Interval, get_bvs_from_abst(arg, domain, w))
+            for arg, w in zip(args, arg_widths)
         )
-        ideal_range = get_bvs_from_abst(ideal, domain, bw)
+        ideal_range = get_bvs_from_abst(ideal, domain, result_width)
         feats.append((arg_ranges, ideal_range))
 
     def dominates(a: CRFeature, b: CRFeature) -> bool:
@@ -184,9 +204,21 @@ def prune_file(path: Path, out_dir: Path, options: PruneOptions) -> FileStats:
     frame = data.enumdata
 
     if "ideal" not in frame.columns:
+        if len(frame) == 0:
+            return FileStats.zero()
         sys.exit(f"{path.name}: no 'ideal' column; run max-precise first")
 
     arg_cols = [f"arg_{a}" for a in range(data.metadata.arity)]
+
+    # Per-operand types from the pattern's lowering: a Select condition is i1,
+    # an icmp result is i1, etc., independent of the group's data width. Reuse
+    # the same inference max-precise used to fill the table so each operand and
+    # the ideal are parsed at their true width rather than a single `bw`.
+    hlprs = HelperFuncs(data.metadata.op, data.metadata.domain)
+
+    def widths_for(bw: int) -> tuple[list[int], int]:
+        arg_widths = [_concrete_width(t, bw) for t in hlprs.conc_arg_ty]
+        return arg_widths, _concrete_width(hlprs.conc_ret_ty, bw)
 
     if options.drop_locally_complete and "sequential_ideal" not in frame.columns:
         sys.exit(f"{path.name}: no 'sequential_ideal' column")
@@ -215,7 +247,9 @@ def prune_file(path: Path, out_dir: Path, options: PruneOptions) -> FileStats:
                 continue
             if options.drop_locally_complete and ideal == sequential_ideal:
                 continue
-            if options.drop_top and is_top(ideal, data.metadata.domain, bw):
+            if options.drop_top and is_top(
+                ideal, data.metadata.domain, widths_for(bw)[1]
+            ):
                 n_top += 1
                 continue
             groups[bw].append((pos, argvals, ideal))
@@ -227,8 +261,14 @@ def prune_file(path: Path, out_dir: Path, options: PruneOptions) -> FileStats:
     merged_counts: dict[int, int] = {}
     has_count = "count" in frame.columns
     for bw, grp in groups.items():
+        arg_widths, result_width = widths_for(bw)
         targets = (
-            prune_group([(a, d) for _, a, d in grp], data.metadata.domain, bw)
+            prune_group(
+                [(a, d) for _, a, d in grp],
+                data.metadata.domain,
+                arg_widths,
+                result_width,
+            )
             if options.prune_subsumed
             else list(range(len(grp)))
         )


### PR DESCRIPTION
- Fix bitwidth parsing in pruning: parse each operand/ideal at its true width (e.g. i1 Select conditions) instead of one group bw
- Skip pointer select: return `std::nullopt` when ResBW == 0 to avoid zero-width KnownBits.
- Add WORK_DIR to phase1: persist intermediates instead of using a wiped temp dir
- Default --drop-locally-complete on.
- Update the README for scripts